### PR TITLE
Feat/4/dashboard overview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
 DB_USER=desknin-app
 DB_PASSWORD=your-password
 DB_NAME=desknin
+
+ConnectionStrings__DefaultConnection=Host=localhost;Port=5432;Database=desknin;Username=desknin-app;Password=your-password
+
+Resend__ApiKey=
+Resend__FromEmail=no-reply@your-domain.com
+Resend__ReplyToEmail=
+Resend__LogoUrl=

--- a/DeskNin.Tests/Controllers/DashboardControllerTest.cs
+++ b/DeskNin.Tests/Controllers/DashboardControllerTest.cs
@@ -1,8 +1,10 @@
 using DeskNin.Controllers;
 using DeskNin.Data;
+using DeskNin.Models;
 using DeskNin.Tests.TestHelpers;
 using DeskNin.ViewModels;
 using JetBrains.Annotations;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DeskNin.Tests.Controllers;
@@ -22,12 +24,113 @@ public class DashboardControllerTest : IDisposable
     [Fact]
     public async Task Index_Returns_ViewResult_With_DashboardViewModel()
     {
+        // Arrange: seed a few tickets + comments in the in-memory database.
+        var alice = new IdentityUser { Id = "u1", UserName = "alice", Email = "alice@example.com" };
+        var bob = new IdentityUser { Id = "u2", UserName = "bob", Email = "bob@example.com" };
+        var carol = new IdentityUser { Id = "u3", UserName = "carol", Email = "carol@example.com" };
+        _context.Users.AddRange(alice, bob, carol);
+
+        var now = DateTime.UtcNow;
+
+        // Open + High priority (no comments)
+        _context.Tickets.Add(new Ticket
+        {
+            Id = 1,
+            Title = "Open high priority",
+            Description = "desc",
+            Status = TicketStatus.Open,
+            Priority = TicketPriority.High,
+            AuthorId = alice.Id,
+            CreatedAtUtc = now.AddMinutes(-30),
+            UpdatedAtUtc = now.AddMinutes(-30)
+        });
+
+        // In progress + Low priority.
+        _context.Tickets.Add(new Ticket
+        {
+            Id = 2,
+            Title = "In progress low",
+            Description = "desc",
+            Status = TicketStatus.InProgress,
+            Priority = TicketPriority.Low,
+            AuthorId = bob.Id,
+            CreatedAtUtc = now.AddMinutes(-120),
+            UpdatedAtUtc = now.AddMinutes(-10)
+        });
+
+        // Resolved + Critical priority.
+        _context.Tickets.Add(new Ticket
+        {
+            Id = 3,
+            Title = "Resolved critical",
+            Description = "desc",
+            Status = TicketStatus.Resolved,
+            Priority = TicketPriority.Critical,
+            AuthorId = carol.Id,
+            CreatedAtUtc = now.AddHours(-2),
+            UpdatedAtUtc = now.AddMinutes(-5)
+        });
+
+        // Open + Medium priority with a comment.
+        _context.Tickets.Add(new Ticket
+        {
+            Id = 4,
+            Title = "Open with comment",
+            Description = "desc",
+            Status = TicketStatus.Open,
+            Priority = TicketPriority.Medium,
+            AuthorId = alice.Id,
+            CreatedAtUtc = now.AddMinutes(-60),
+            UpdatedAtUtc = now.AddMinutes(-2)
+        });
+
+        _context.TicketComments.Add(new TicketComment
+        {
+            Id = 1,
+            TicketId = 4,
+            AuthorId = bob.Id,
+            Content = "comment",
+            CreatedAtUtc = now.AddMinutes(-2)
+        });
+
+        await _context.SaveChangesAsync();
+
         var controller = new DashboardController(_context);
         controller.SetAnonymousUser();
 
         var result = await controller.Index();
 
         var viewResult = Assert.IsType<ViewResult>(result);
-        Assert.IsType<DashboardViewModel>(viewResult.Model);
+        var model = Assert.IsType<DashboardViewModel>(viewResult.Model);
+
+        Assert.Equal(1, model.OpenCount);
+        Assert.Equal(1, model.InProgressCount);
+        Assert.Equal(1, model.ResolvedCount);
+        Assert.Equal(2, model.HighPriorityCount); // High + Critical (tickets 1 and 3)
+
+        Assert.NotNull(model.PriorityBreakdown);
+        Assert.Equal(3, model.PriorityBreakdown.Count);
+
+        var low = model.PriorityBreakdown.FirstOrDefault(b => b.Label == "Low");
+        var medium = model.PriorityBreakdown.FirstOrDefault(b => b.Label == "Medium");
+        var high = model.PriorityBreakdown.FirstOrDefault(b => b.Label == "High");
+        Assert.NotNull(low);
+        Assert.NotNull(medium);
+        Assert.NotNull(high);
+        Assert.Equal(1, low!.Count); // ticket 2
+        Assert.Equal(1, medium!.Count); // ticket 4
+        Assert.Equal(2, high!.Count); // tickets 1 and 3
+
+        Assert.NotNull(model.RecentActivities);
+        Assert.Equal(4, model.RecentActivities.Count); // seeded 4 tickets
+
+        var mostRecent = model.RecentActivities[0];
+        Assert.Equal(4, mostRecent.TicketId);
+        Assert.Equal("bob", mostRecent.AuthorName); // author from latest comment
+        Assert.Equal("Ticket updated", mostRecent.Label); // Open + comment => "Ticket updated"
+
+        var resolvedActivity = model.RecentActivities.SingleOrDefault(a => a.TicketId == 3);
+        Assert.NotNull(resolvedActivity);
+        Assert.Equal("Ticket resolved", resolvedActivity!.Label);
     }
 }

--- a/DeskNin.Tests/Controllers/DashboardControllerTest.cs
+++ b/DeskNin.Tests/Controllers/DashboardControllerTest.cs
@@ -103,7 +103,7 @@ public class DashboardControllerTest : IDisposable
         var viewResult = Assert.IsType<ViewResult>(result);
         var model = Assert.IsType<DashboardViewModel>(viewResult.Model);
 
-        Assert.Equal(1, model.OpenCount);
+        Assert.Equal(2, model.OpenCount);
         Assert.Equal(1, model.InProgressCount);
         Assert.Equal(1, model.ResolvedCount);
         Assert.Equal(2, model.HighPriorityCount); // High + Critical (tickets 1 and 3)

--- a/DeskNin.Tests/Controllers/SettingsControllerTest.cs
+++ b/DeskNin.Tests/Controllers/SettingsControllerTest.cs
@@ -1,10 +1,13 @@
+using System.Threading;
 using DeskNin.Controllers;
 using DeskNin.Data;
+using DeskNin.Models;
 using DeskNin.Tests.TestHelpers;
 using DeskNin.ViewModels;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace DeskNin.Tests.Controllers;
 
@@ -21,10 +24,44 @@ public class SettingsControllerTest : IDisposable
 
     public void Dispose() => _context.Dispose();
 
+    private SettingsController CreateController() => new(_context, _userManager);
+
+    [Fact]
+    public async Task Index_Get_Returns_View_With_Model()
+    {
+        var controller = CreateController();
+        controller.SetAnonymousUser();
+
+        var result = await controller.Index(CancellationToken.None);
+
+        var view = Assert.IsType<ViewResult>(result);
+        var vm = Assert.IsType<SettingsIndexViewModel>(view.Model);
+        Assert.False(vm.CanManageSystemEmail);
+    }
+
+    [Fact]
+    public async Task SaveEmailNotifications_Post_As_Admin_Updates_Database()
+    {
+        var user = new IdentityUser { UserName = "adminsettings", Email = "adminsettings@example.com" };
+        await _userManager.CreateAsync(user, "Password123!");
+
+        var controller = CreateController();
+        controller.SetUser(user, "Admin");
+
+        var result = await controller.SaveEmailNotifications(true, CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(SettingsController.Index), redirect.ActionName);
+
+        var stored = await _context.Settings.AsNoTracking()
+            .SingleAsync(s => s.Key == SettingKeys.EmailNotificationsEnabled);
+        Assert.True(SettingValue.AsBool(stored.Value));
+    }
+
     [Fact]
     public void ChangePassword_Get_Returns_ViewResult()
     {
-        var controller = new SettingsController(_userManager);
+        var controller = CreateController();
         controller.SetAnonymousUser();
 
         var result = controller.ChangePassword();
@@ -35,7 +72,7 @@ public class SettingsControllerTest : IDisposable
     [Fact]
     public async Task ChangePassword_Post_With_Invalid_Model_Returns_View()
     {
-        var controller = new SettingsController(_userManager);
+        var controller = CreateController();
         controller.SetAnonymousUser();
         controller.ModelState.AddModelError("CurrentPassword", "Required");
 
@@ -58,7 +95,7 @@ public class SettingsControllerTest : IDisposable
         var user = new IdentityUser { UserName = "settingsuser", Email = "settings@example.com" };
         await _userManager.CreateAsync(user, "OldPassword123!");
 
-        var controller = new SettingsController(_userManager);
+        var controller = CreateController();
         controller.SetUser(user);
 
         var model = new ChangePasswordViewModel
@@ -84,7 +121,7 @@ public class SettingsControllerTest : IDisposable
         var user = new IdentityUser { UserName = "wronguser", Email = "wrong@example.com" };
         await _userManager.CreateAsync(user, "CorrectPassword123!");
 
-        var controller = new SettingsController(_userManager);
+        var controller = CreateController();
         controller.SetUser(user);
 
         var model = new ChangePasswordViewModel
@@ -106,7 +143,7 @@ public class SettingsControllerTest : IDisposable
     {
         var user = new IdentityUser { UserName = "ghost", Email = "ghost@example.com", Id = "ghost-id" };
 
-        var controller = new SettingsController(_userManager);
+        var controller = CreateController();
         controller.SetUser(user);
 
         var model = new ChangePasswordViewModel

--- a/DeskNin.Tests/Controllers/TeamControllerTest.cs
+++ b/DeskNin.Tests/Controllers/TeamControllerTest.cs
@@ -6,6 +6,7 @@ using DeskNin.ViewModels;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace DeskNin.Tests.Controllers;
@@ -17,18 +18,33 @@ public class TeamControllerTest : IDisposable
     private UserManager<IdentityUser> _userManager = null!;
     private RoleManager<IdentityRole> _roleManager = null!;
     private readonly Mock<IPasswordGenerator> _passwordGenerator = new();
+    private readonly Mock<IAppSettingsService> _appSettingsService = new();
+    private readonly Mock<IAppEmailSender> _appEmailSender = new();
+    private readonly Mock<IEmailTemplateService> _emailTemplateService = new();
 
     public TeamControllerTest()
     {
         (_context, _userManager, _roleManager) = IdentityTestHelpers.CreateIdentityServices();
         _passwordGenerator.Setup(p => p.GenerateIdentityCompliantPasswordAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync("GeneratedPass123!");
+        _appSettingsService.Setup(s => s.IsEmailEnabledAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _emailTemplateService.Setup(t => t.BuildOnboardingBody(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns("<p>onboarding</p>");
     }
 
     public void Dispose() => _context.Dispose();
 
     private TeamController CreateController() =>
-        new(_context, _userManager, _roleManager, _passwordGenerator.Object);
+        new(
+            _context,
+            _userManager,
+            _roleManager,
+            _passwordGenerator.Object,
+            _appSettingsService.Object,
+            _appEmailSender.Object,
+            _emailTemplateService.Object,
+            Mock.Of<ILogger<TeamController>>());
 
     [Fact]
     public async Task Index_Returns_ViewResult_With_Users()
@@ -66,6 +82,9 @@ public class TeamControllerTest : IDisposable
         var user = await _userManager.FindByEmailAsync("test@example.com");
         Assert.NotNull(user);
         Assert.Equal("testuser", user.UserName);
+
+        var roles = await _userManager.GetRolesAsync(user);
+        Assert.Contains("User", roles);
     }
 
     [Fact]
@@ -88,6 +107,39 @@ public class TeamControllerTest : IDisposable
         var redirect = Assert.IsType<RedirectToActionResult>(result);
         Assert.Equal("Index", redirect.ActionName);
         Assert.True(controller.TempData.ContainsKey("AddMemberError"));
+    }
+
+    [Fact]
+    public async Task Index_Post_With_EmailEnabled_Sends_Onboarding_Email()
+    {
+        _appSettingsService.Setup(s => s.IsEmailEnabledAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var controller = CreateController();
+        controller.SetAnonymousUser();
+
+        var form = new UserForm
+        {
+            Username = "emailuser",
+            Email = "emailuser@example.com",
+            Password = "Password123!",
+            ConfirmPassword = "Password123!",
+            Role = "User"
+        };
+
+        await controller.Index(form);
+
+        _emailTemplateService.Verify(t => t.BuildOnboardingBody(
+                "emailuser@example.com",
+                It.IsAny<string>()),
+            Times.Once);
+
+        _appEmailSender.Verify(s => s.SendEmailAsync(
+                "emailuser@example.com",
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/DeskNin.Tests/Controllers/TeamControllerTest.cs
+++ b/DeskNin.Tests/Controllers/TeamControllerTest.cs
@@ -1,10 +1,12 @@
 using DeskNin.Controllers;
 using DeskNin.Data;
+using DeskNin.Services;
 using DeskNin.Tests.TestHelpers;
 using DeskNin.ViewModels;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Moq;
 
 namespace DeskNin.Tests.Controllers;
 
@@ -14,18 +16,24 @@ public class TeamControllerTest : IDisposable
     private ApplicationDbContext _context = null!;
     private UserManager<IdentityUser> _userManager = null!;
     private RoleManager<IdentityRole> _roleManager = null!;
+    private readonly Mock<IPasswordGenerator> _passwordGenerator = new();
 
     public TeamControllerTest()
     {
         (_context, _userManager, _roleManager) = IdentityTestHelpers.CreateIdentityServices();
+        _passwordGenerator.Setup(p => p.GenerateIdentityCompliantPasswordAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("GeneratedPass123!");
     }
 
     public void Dispose() => _context.Dispose();
 
+    private TeamController CreateController() =>
+        new(_context, _userManager, _roleManager, _passwordGenerator.Object);
+
     [Fact]
     public async Task Index_Returns_ViewResult_With_Users()
     {
-        var controller = new TeamController(_context, _userManager, _roleManager);
+        var controller = CreateController();
         controller.SetAnonymousUser();
 
         var result = await controller.Index();
@@ -38,7 +46,7 @@ public class TeamControllerTest : IDisposable
     [Fact]
     public async Task Index_Post_With_Valid_Form_Creates_User_And_Redirects()
     {
-        var controller = new TeamController(_context, _userManager, _roleManager);
+        var controller = CreateController();
         controller.SetAnonymousUser();
 
         var form = new UserForm
@@ -63,7 +71,7 @@ public class TeamControllerTest : IDisposable
     [Fact]
     public async Task Index_Post_With_Invalid_Password_Redirects_With_Error()
     {
-        var controller = new TeamController(_context, _userManager, _roleManager);
+        var controller = CreateController();
         controller.SetAnonymousUser();
 
         var form = new UserForm
@@ -89,7 +97,7 @@ public class TeamControllerTest : IDisposable
         await _userManager.CreateAsync(user, "Password123!");
         await _userManager.AddToRoleAsync(user, "User");
 
-        var controller = new TeamController(_context, _userManager, _roleManager);
+        var controller = CreateController();
         controller.SetAnonymousUser();
 
         var result = await controller.Edit(user.Id);
@@ -105,7 +113,7 @@ public class TeamControllerTest : IDisposable
     [Fact]
     public async Task Edit_Get_With_Invalid_Id_Returns_NotFound()
     {
-        var controller = new TeamController(_context, _userManager, _roleManager);
+        var controller = CreateController();
         controller.SetAnonymousUser();
 
         var result = await controller.Edit("non-existent-id");
@@ -120,7 +128,7 @@ public class TeamControllerTest : IDisposable
         await _userManager.CreateAsync(user, "Password123!");
         await _userManager.AddToRoleAsync(user, "User");
 
-        var controller = new TeamController(_context, _userManager, _roleManager);
+        var controller = CreateController();
         controller.SetAnonymousUser();
 
         var form = new UserForm
@@ -148,7 +156,7 @@ public class TeamControllerTest : IDisposable
     [Fact]
     public async Task Edit_Post_With_Invalid_Id_Returns_NotFound()
     {
-        var controller = new TeamController(_context, _userManager, _roleManager);
+        var controller = CreateController();
         controller.SetAnonymousUser();
 
         var form = new UserForm

--- a/DeskNin.Tests/Controllers/TicketsControllerTest.cs
+++ b/DeskNin.Tests/Controllers/TicketsControllerTest.cs
@@ -1,12 +1,15 @@
 using DeskNin.Controllers;
 using DeskNin.Data;
 using DeskNin.Models;
+using DeskNin.Services;
 using DeskNin.Tests.TestHelpers;
 using DeskNin.ViewModels;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
 
 namespace DeskNin.Tests.Controllers;
 
@@ -15,6 +18,7 @@ public class TicketsControllerTest : IDisposable
 {
     private readonly ApplicationDbContext _context;
     private readonly UserManager<IdentityUser> _userManager;
+    private readonly Mock<ITicketNotificationService> _ticketNotificationService = new();
 
     public TicketsControllerTest()
     {
@@ -26,7 +30,7 @@ public class TicketsControllerTest : IDisposable
     [Fact]
     public async Task Index_Returns_ViewResult_With_TicketListViewModel()
     {
-        var controller = new TicketsController(_context, _userManager);
+        var controller = new TicketsController(_context, _userManager, _ticketNotificationService.Object, Mock.Of<ILogger<TicketsController>>());
         controller.SetAnonymousUser();
 
         var result = await controller.Index();
@@ -41,7 +45,7 @@ public class TicketsControllerTest : IDisposable
         var user = new IdentityUser { UserName = "author", Email = "author@test.com" };
         await _userManager.CreateAsync(user, "Password123!");
 
-        var controller = new TicketsController(_context, _userManager);
+        var controller = new TicketsController(_context, _userManager, _ticketNotificationService.Object, Mock.Of<ILogger<TicketsController>>());
         controller.SetUser(user);
 
         var form = new TicketFormViewModel
@@ -68,7 +72,7 @@ public class TicketsControllerTest : IDisposable
     [Fact]
     public async Task Edit_Get_With_Invalid_Id_Returns_NotFound()
     {
-        var controller = new TicketsController(_context, _userManager);
+        var controller = new TicketsController(_context, _userManager, _ticketNotificationService.Object, Mock.Of<ILogger<TicketsController>>());
         controller.SetAnonymousUser();
 
         var result = await controller.Edit(9999);
@@ -92,7 +96,7 @@ public class TicketsControllerTest : IDisposable
         _context.Tickets.Add(ticket);
         await _context.SaveChangesAsync();
 
-        var controller = new TicketsController(_context, _userManager);
+        var controller = new TicketsController(_context, _userManager, _ticketNotificationService.Object, Mock.Of<ILogger<TicketsController>>());
         controller.SetUser(user);
 
         var result = await controller.UpdateStatus(ticket.Id, TicketStatus.Resolved);
@@ -103,6 +107,12 @@ public class TicketsControllerTest : IDisposable
         var updated = await _context.Tickets.FindAsync(ticket.Id);
         Assert.NotNull(updated);
         Assert.Equal(TicketStatus.Resolved, updated!.Status);
+        _ticketNotificationService.Verify(n => n.NotifyTicketUpdatedAsync(
+            It.IsAny<Ticket>(),
+            user.Id,
+            "status updated",
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -124,7 +134,7 @@ public class TicketsControllerTest : IDisposable
         _context.Tickets.Add(ticket);
         await _context.SaveChangesAsync();
 
-        var controller = new TicketsController(_context, _userManager);
+        var controller = new TicketsController(_context, _userManager, _ticketNotificationService.Object, Mock.Of<ILogger<TicketsController>>());
         controller.SetUser(commenter);
 
         var form = new CommentFormViewModel
@@ -142,5 +152,11 @@ public class TicketsControllerTest : IDisposable
         Assert.NotNull(comment);
         Assert.Equal(commenter.Id, comment!.AuthorId);
         Assert.Equal(form.Content, comment.Content);
+        _ticketNotificationService.Verify(n => n.NotifyTicketUpdatedAsync(
+            It.IsAny<Ticket>(),
+            commenter.Id,
+            "new comment",
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/DeskNin.Tests/Services/EmailTemplateServiceTest.cs
+++ b/DeskNin.Tests/Services/EmailTemplateServiceTest.cs
@@ -6,7 +6,7 @@ namespace DeskNin.Tests.Services;
 public class EmailTemplateServiceTest
 {
     private readonly EmailTemplateService _service = new(
-        Options.Create(new ResendOptions { LogoUrl = "https://example.com/logo.png" }));
+        Options.Create(new ResendOptions()));
 
     [Fact]
     public void BuildTicketUpdateBody_Includes_Branding_And_Assignee()
@@ -23,7 +23,7 @@ public class EmailTemplateServiceTest
         Assert.Contains("VPN access issue", html);
         Assert.Contains("Assigned to", html);
         Assert.Contains("bob", html);
-        Assert.Contains("https://example.com/logo.png", html);
+        Assert.Contains("Ticket management system", html);
     }
 
     [Fact]

--- a/DeskNin.Tests/Services/EmailTemplateServiceTest.cs
+++ b/DeskNin.Tests/Services/EmailTemplateServiceTest.cs
@@ -1,0 +1,36 @@
+using DeskNin.Services;
+using Microsoft.Extensions.Options;
+
+namespace DeskNin.Tests.Services;
+
+public class EmailTemplateServiceTest
+{
+    private readonly EmailTemplateService _service = new(
+        Options.Create(new ResendOptions { LogoUrl = "https://example.com/logo.png" }));
+
+    [Fact]
+    public void BuildTicketUpdateBody_Includes_Branding_And_Assignee()
+    {
+        var html = _service.BuildTicketUpdateBody(
+            "assignment updated",
+            42,
+            "VPN access issue",
+            "alice",
+            "Assigned technician: bob.",
+            "bob");
+
+        Assert.Contains("DeskNin", html);
+        Assert.Contains("VPN access issue", html);
+        Assert.Contains("Assigned to", html);
+        Assert.Contains("bob", html);
+        Assert.Contains("https://example.com/logo.png", html);
+    }
+
+    [Fact]
+    public void BuildForgotPasswordBody_Includes_Reset_Cta()
+    {
+        var html = _service.BuildForgotPasswordBody("https://app/reset");
+        Assert.Contains("Reset password", html);
+        Assert.Contains("https://app/reset", html);
+    }
+}

--- a/DeskNin.Tests/Services/ResendEmailSenderTest.cs
+++ b/DeskNin.Tests/Services/ResendEmailSenderTest.cs
@@ -1,0 +1,33 @@
+using DeskNin.Services;
+using Microsoft.Extensions.Options;
+
+namespace DeskNin.Tests.Services;
+
+public class ResendEmailSenderTest
+{
+    [Fact]
+    public async Task SendEmailAsync_With_Local_FromEmail_Throws_Clear_Error()
+    {
+        var options = Options.Create(new ResendOptions
+        {
+            ApiKey = "re_test",
+            FromEmail = "admin@desknin.local"
+        });
+
+        using var http = new HttpClient(new StubHandler());
+        var sender = new ResendEmailSender(http, options);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sender.SendEmailAsync("user@example.com", "subject", "<p>body</p>"));
+
+        Assert.Contains("invalid for production sending", ex.Message);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+        }
+    }
+}

--- a/DeskNin.Tests/Services/TicketNotificationServiceTest.cs
+++ b/DeskNin.Tests/Services/TicketNotificationServiceTest.cs
@@ -1,0 +1,77 @@
+using DeskNin.Models;
+using DeskNin.Services;
+using DeskNin.Tests.TestHelpers;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace DeskNin.Tests.Services;
+
+public class TicketNotificationServiceTest : IDisposable
+{
+    private readonly DeskNin.Data.ApplicationDbContext _context;
+    private readonly UserManager<IdentityUser> _userManager;
+
+    public TicketNotificationServiceTest()
+    {
+        (_context, _userManager, _) = IdentityTestHelpers.CreateIdentityServices();
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public async Task NotifyTicketUpdatedAsync_Uses_Title_In_Subject_And_Assignee_In_Body()
+    {
+        var actor = new IdentityUser { UserName = "actor", Email = "actor@example.com" };
+        var author = new IdentityUser { UserName = "author", Email = "author@example.com" };
+        var assignee = new IdentityUser { UserName = "tech", Email = "tech@example.com" };
+        await _userManager.CreateAsync(actor, "Password123!");
+        await _userManager.CreateAsync(author, "Password123!");
+        await _userManager.CreateAsync(assignee, "Password123!");
+
+        var settings = new Mock<IAppSettingsService>();
+        settings.Setup(s => s.IsEmailEnabledAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var template = new EmailTemplateService(
+            Options.Create(new ResendOptions { LogoUrl = "https://example.com/logo.png" }));
+        string? sentSubject = null;
+        string? sentBody = null;
+
+        var sender = new Mock<IAppEmailSender>();
+        sender.Setup(s => s.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string, CancellationToken>((_, subject, body, _) =>
+            {
+                sentSubject = subject;
+                sentBody = body;
+            })
+            .Returns(Task.CompletedTask);
+
+        var service = new TicketNotificationService(
+            _userManager,
+            settings.Object,
+            sender.Object,
+            template,
+            Mock.Of<ILogger<TicketNotificationService>>());
+
+        var ticket = new Ticket
+        {
+            Id = 100,
+            Title = "Cannot access VPN from home",
+            Description = "desc",
+            AuthorId = author.Id,
+            AssignedTechnicianId = assignee.Id,
+            Status = TicketStatus.InProgress,
+            Priority = TicketPriority.High
+        };
+
+        await service.NotifyTicketUpdatedAsync(ticket, actor.Id, "assignment updated", "Assigned technician: tech.");
+
+        Assert.NotNull(sentSubject);
+        Assert.Contains("Cannot access VPN from home", sentSubject);
+
+        Assert.NotNull(sentBody);
+        Assert.Contains("Assigned to", sentBody);
+        Assert.Contains("tech", sentBody);
+    }
+}

--- a/DeskNin.Tests/TestHelpers/ControllerTestHelpers.cs
+++ b/DeskNin.Tests/TestHelpers/ControllerTestHelpers.cs
@@ -38,7 +38,7 @@ public static class ControllerTestHelpers
         return httpContext;
     }
 
-    public static void SetUser(this Controller controller, IdentityUser user)
+    public static void SetUser(this Controller controller, IdentityUser user, params string[] roles)
     {
         var claims = new List<Claim>
         {
@@ -46,6 +46,9 @@ public static class ControllerTestHelpers
             new(ClaimTypes.Name, user.UserName ?? user.Email ?? ""),
             new(ClaimTypes.Email, user.Email ?? "")
         };
+        foreach (var role in roles)
+            claims.Add(new Claim(ClaimTypes.Role, role));
+
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var principal = new ClaimsPrincipal(identity);
         controller.ControllerContext = new ControllerContext { HttpContext = CreateHttpContext(principal) };

--- a/DeskNin.Tests/TestHelpers/IdentityTestHelpers.cs
+++ b/DeskNin.Tests/TestHelpers/IdentityTestHelpers.cs
@@ -2,8 +2,6 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Moq;
 using DeskNin.Data;
 
 namespace DeskNin.Tests.TestHelpers;
@@ -23,47 +21,31 @@ public static class IdentityTestHelpers
 
     public static UserManager<IdentityUser> CreateUserManager(ApplicationDbContext context)
     {
-        var userStore = new Microsoft.AspNetCore.Identity.EntityFrameworkCore.UserStore<IdentityUser>(context);
-        var options = new Mock<IOptions<IdentityOptions>>();
-        options.Setup(o => o.Value).Returns(new IdentityOptions { Lockout = { AllowedForNewUsers = false } });
-
-        var userValidators = new List<IUserValidator<IdentityUser>> { new UserValidator<IdentityUser>() };
-        var pwdValidators = new List<IPasswordValidator<IdentityUser>> { new PasswordValidator<IdentityUser>() };
-
-        var userManager = new UserManager<IdentityUser>(
-            userStore,
-            options.Object,
-            new PasswordHasher<IdentityUser>(),
-            userValidators,
-            pwdValidators,
-            new UpperInvariantLookupNormalizer(),
-            new IdentityErrorDescriber(),
-            new ServiceCollection().BuildServiceProvider(),
-            Mock.Of<ILogger<UserManager<IdentityUser>>>());
-
-        return userManager;
+        return CreateIdentityServices().UserManager;
     }
 
     public static RoleManager<IdentityRole> CreateRoleManager(ApplicationDbContext context)
     {
-        var roleStore = new Microsoft.AspNetCore.Identity.EntityFrameworkCore.RoleStore<IdentityRole>(context);
-        var roleValidators = new List<IRoleValidator<IdentityRole>> { new RoleValidator<IdentityRole>() };
-
-        var roleManager = new RoleManager<IdentityRole>(
-            roleStore,
-            roleValidators,
-            new UpperInvariantLookupNormalizer(),
-            new IdentityErrorDescriber(),
-            Mock.Of<ILogger<RoleManager<IdentityRole>>>());
-
-        return roleManager;
+        return CreateIdentityServices().RoleManager;
     }
 
     public static (ApplicationDbContext Context, UserManager<IdentityUser> UserManager, RoleManager<IdentityRole> RoleManager) CreateIdentityServices()
     {
-        var context = CreateInMemoryContext();
-        var userManager = CreateUserManager(context);
-        var roleManager = CreateRoleManager(context);
+        var databaseName = Guid.NewGuid().ToString();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDataProtection();
+        services.AddDbContext<ApplicationDbContext>(options => options.UseInMemoryDatabase(databaseName));
+        services.AddIdentityCore<IdentityUser>(options => { options.Lockout.AllowedForNewUsers = false; })
+            .AddRoles<IdentityRole>()
+            .AddEntityFrameworkStores<ApplicationDbContext>()
+            .AddDefaultTokenProviders();
+
+        var provider = services.BuildServiceProvider();
+        var context = provider.GetRequiredService<ApplicationDbContext>();
+        context.Database.EnsureCreated();
+        var userManager = provider.GetRequiredService<UserManager<IdentityUser>>();
+        var roleManager = provider.GetRequiredService<RoleManager<IdentityRole>>();
         return (context, userManager, roleManager);
     }
 }

--- a/DeskNin/Areas/Identity/Pages/Account/ForgotPassword.cshtml
+++ b/DeskNin/Areas/Identity/Pages/Account/ForgotPassword.cshtml
@@ -1,5 +1,5 @@
 @page
-@model Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Internal.ForgotPasswordModel
+@model DeskNin.Areas.Identity.Pages.Account.ForgotPasswordModel
 @{
     ViewData["Title"] = "Forgot password?";
     ViewData["LogoSize"] = 64;
@@ -15,6 +15,13 @@
         <div class="desknin-auth-card card shadow rounded-3 p-4 position-relative">
             <h2 class="fs-4 fw-semibold mb-1">Forgot your password?</h2>
             <p class="small text-body-secondary mb-4">Enter your email to receive the password reset link</p>
+
+            @if (Model.EmailSent)
+            {
+                <div class="alert alert-success small" role="alert">
+                    If your account exists, a password reset email has been sent.
+                </div>
+            }
 
             <form method="post">
                 <div asp-validation-summary="ModelOnly" class="text-danger small mb-3"></div>

--- a/DeskNin/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
+++ b/DeskNin/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
@@ -1,0 +1,84 @@
+using System.ComponentModel.DataAnnotations;
+using DeskNin.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace DeskNin.Areas.Identity.Pages.Account;
+
+public class ForgotPasswordModel(
+    UserManager<IdentityUser> userManager,
+    IAppSettingsService appSettingsService,
+    IAppEmailSender appEmailSender,
+    IEmailTemplateService emailTemplateService,
+    ILogger<ForgotPasswordModel> logger) : PageModel
+{
+    private readonly UserManager<IdentityUser> _userManager = userManager;
+    private readonly IAppSettingsService _appSettingsService = appSettingsService;
+    private readonly IAppEmailSender _appEmailSender = appEmailSender;
+    private readonly IEmailTemplateService _emailTemplateService = emailTemplateService;
+    private readonly ILogger<ForgotPasswordModel> _logger = logger;
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public bool EmailSent { get; private set; }
+
+    public sealed class InputModel
+    {
+        [Required(ErrorMessage = "The Email field is required.")]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+    }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync(CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+            return Page();
+
+        var user = await _userManager.FindByEmailAsync(Input.Email);
+        if (user == null)
+        {
+            // Keep response neutral to avoid account enumeration.
+            EmailSent = true;
+            return Page();
+        }
+
+        if (!await _appSettingsService.IsEmailEnabledAsync(cancellationToken))
+        {
+            EmailSent = true;
+            return Page();
+        }
+
+        var code = await _userManager.GeneratePasswordResetTokenAsync(user);
+        var encodedCode = WebEncoders.Base64UrlEncode(System.Text.Encoding.UTF8.GetBytes(code));
+        var callbackUrl = Url.Page(
+            "/Account/ResetPassword",
+            pageHandler: null,
+            values: new { area = "Identity", code = encodedCode, email = user.Email },
+            protocol: Request.Scheme);
+
+        var body = _emailTemplateService.BuildForgotPasswordBody(callbackUrl ?? string.Empty);
+
+        try
+        {
+            await _appEmailSender.SendEmailAsync(
+                user.Email!,
+                "DeskNin password reset",
+                body,
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to send forgot-password email for user {UserId}", user.Id);
+        }
+
+        EmailSent = true;
+        return Page();
+    }
+}

--- a/DeskNin/Areas/Identity/Pages/Account/Login.cshtml
+++ b/DeskNin/Areas/Identity/Pages/Account/Login.cshtml
@@ -8,7 +8,9 @@
 <div class="desknin-auth-page min-vh-100 d-flex align-items-center justify-content-center p-4">
     <div class="w-100" style="max-width: 28rem;">
         <div class="text-center mb-5">
-            <partial name="~/Views/Shared/_Logo.cshtml"/>
+            <a href="/" class="d-inline-flex flex-column align-items-center text-decoration-none text-body" aria-label="DeskNin home">
+                <partial name="~/Views/Shared/_Logo.cshtml"/>
+            </a>
             <p class="mt-2 small text-body-secondary">Ticket Management System</p>
         </div>
 

--- a/DeskNin/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/DeskNin/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -76,6 +76,18 @@ public class LoginModel : PageModel
             if (result.Succeeded)
             {
                 _logger.LogInformation("User logged in.");
+
+                var roles = await _userManager.GetRolesAsync(user);
+                var isBasicUser = roles.Contains("User") && !roles.Contains("Admin") && !roles.Contains("Technical");
+
+                // Role User cannot access Dashboard: force My Tickets when returnUrl is empty or dashboard.
+                if (isBasicUser && (string.IsNullOrWhiteSpace(returnUrl) || IsDashboardReturnUrl(returnUrl)))
+                    return LocalRedirect(Url.Content("~/Tickets/MyTickets"));
+
+                // No explicit return target: role-based default.
+                if (!Request.Query.ContainsKey("returnUrl"))
+                    return LocalRedirect(isBasicUser ? Url.Content("~/Tickets/MyTickets") : Url.Content("~/Dashboard"));
+
                 return LocalRedirect(returnUrl);
             }
             if (result.IsLockedOut)
@@ -89,5 +101,14 @@ public class LoginModel : PageModel
 
         ReturnUrl = returnUrl;
         return Page();
+    }
+
+    private static bool IsDashboardReturnUrl(string? returnUrl)
+    {
+        if (string.IsNullOrWhiteSpace(returnUrl))
+            return true;
+
+        var normalized = returnUrl.Trim().ToLowerInvariant();
+        return normalized == "/dashboard" || normalized == "~/dashboard";
     }
 }

--- a/DeskNin/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/DeskNin/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -72,7 +72,7 @@ public class LoginModel : PageModel
                 return Page();
             }
 
-            var result = await _signInManager.PasswordSignInAsync(user.UserName!, Input.Password, Input.RememberMe, lockoutOnFailure: true);
+            var result = await _signInManager.PasswordSignInAsync(user, Input.Password, Input.RememberMe, lockoutOnFailure: true);
             if (result.Succeeded)
             {
                 _logger.LogInformation("User logged in.");

--- a/DeskNin/Areas/Identity/Pages/Account/ResetPassword.cshtml
+++ b/DeskNin/Areas/Identity/Pages/Account/ResetPassword.cshtml
@@ -1,0 +1,57 @@
+@page
+@model DeskNin.Areas.Identity.Pages.Account.ResetPasswordModel
+@{
+    ViewData["Title"] = "Reset password";
+    ViewData["LogoSize"] = 64;
+}
+
+<div class="desknin-auth-page min-vh-100 d-flex align-items-center justify-content-center p-4">
+    <div class="w-100" style="max-width: 28rem;">
+        <div class="text-center mb-5">
+            <partial name="~/Views/Shared/_Logo.cshtml"/>
+            <p class="mt-2 small text-body-secondary">Ticket Management System</p>
+        </div>
+
+        <div class="desknin-auth-card card shadow rounded-3 p-4 position-relative">
+            <h2 class="fs-4 fw-semibold mb-1">Set your password</h2>
+            <p class="small text-body-secondary mb-4">Create a new password to access your account.</p>
+
+            @if (Model.IsSuccess)
+            {
+                <div class="alert alert-success small" role="alert">
+                    Password updated successfully.
+                </div>
+                <div class="d-grid">
+                    <a href="@Url.Page("/Account/Login", new { area = "Identity" })" class="btn btn-primary">Go to sign in</a>
+                </div>
+            }
+            else
+            {
+                <form method="post">
+                    <div asp-validation-summary="ModelOnly" class="text-danger small mb-3"></div>
+
+                    <input asp-for="Input.Email" type="hidden"/>
+                    <input asp-for="Input.Code" type="hidden"/>
+
+                    <div class="mb-3">
+                        <label asp-for="Input.Password" class="form-label small fw-medium">New password</label>
+                        <input asp-for="Input.Password" type="password" class="form-control" autocomplete="new-password"/>
+                        <span asp-validation-for="Input.Password" class="text-danger small"></span>
+                    </div>
+
+                    <div class="mb-4">
+                        <label asp-for="Input.ConfirmPassword" class="form-label small fw-medium">Confirm password</label>
+                        <input asp-for="Input.ConfirmPassword" type="password" class="form-control" autocomplete="new-password"/>
+                        <span asp-validation-for="Input.ConfirmPassword" class="text-danger small"></span>
+                    </div>
+
+                    <button type="submit" class="btn btn-primary w-100 py-2">Save password</button>
+                </form>
+            }
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial"/>
+}

--- a/DeskNin/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
+++ b/DeskNin/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
@@ -1,0 +1,77 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace DeskNin.Areas.Identity.Pages.Account;
+
+public class ResetPasswordModel(UserManager<IdentityUser> userManager) : PageModel
+{
+    private readonly UserManager<IdentityUser> _userManager = userManager;
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public bool IsSuccess { get; private set; }
+
+    public sealed class InputModel
+    {
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+        [DataType(DataType.Password)]
+        public string Password { get; set; } = string.Empty;
+
+        [DataType(DataType.Password)]
+        [Display(Name = "Confirm password")]
+        [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+
+        [Required]
+        public string Code { get; set; } = string.Empty;
+    }
+
+    public IActionResult OnGet(string? code = null, string? email = null)
+    {
+        if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(email))
+            return RedirectToPage("./Login");
+
+        Input = new InputModel
+        {
+            Email = email,
+            Code = code
+        };
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+            return Page();
+
+        var user = await _userManager.FindByEmailAsync(Input.Email);
+        if (user == null)
+        {
+            IsSuccess = true;
+            return Page();
+        }
+
+        var decodedCode = System.Text.Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(Input.Code));
+        var result = await _userManager.ResetPasswordAsync(user, decodedCode, Input.Password);
+        if (result.Succeeded)
+        {
+            IsSuccess = true;
+            return Page();
+        }
+
+        foreach (var error in result.Errors)
+            ModelState.AddModelError(string.Empty, error.Description);
+
+        return Page();
+    }
+}

--- a/DeskNin/Controllers/DashboardController.cs
+++ b/DeskNin/Controllers/DashboardController.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DeskNin.Controllers;
 
-[Authorize]
+[Authorize(Roles = "Admin,Technical")]
 public class DashboardController(ApplicationDbContext context) : Controller
 {
     private readonly ApplicationDbContext _context = context;
@@ -17,6 +17,61 @@ public class DashboardController(ApplicationDbContext context) : Controller
         var openCount = await _context.Tickets.CountAsync(t => t.Status == TicketStatus.Open);
         var inProgressCount = await _context.Tickets.CountAsync(t => t.Status == TicketStatus.InProgress);
         var resolvedCount = await _context.Tickets.CountAsync(t => t.Status == TicketStatus.Resolved);
+
+        var highPriorityCount = await _context.Tickets.CountAsync(t =>
+            t.Priority == TicketPriority.High || t.Priority == TicketPriority.Critical);
+
+        var lowPriorityCount = await _context.Tickets.CountAsync(t => t.Priority == TicketPriority.Low);
+        var mediumPriorityCount = await _context.Tickets.CountAsync(t => t.Priority == TicketPriority.Medium);
+        var highPriorityBucketCount = await _context.Tickets.CountAsync(t =>
+            t.Priority == TicketPriority.High || t.Priority == TicketPriority.Critical);
+
+        var recentActivityTickets = await _context.Tickets
+            .AsNoTracking()
+            .Include(t => t.Author)
+            .Include(t => t.Comments)
+            .ThenInclude(c => c.Author)
+            .OrderByDescending(t => t.UpdatedAtUtc)
+            .Take(10)
+            .ToListAsync();
+
+        var recentActivities = recentActivityTickets
+            .Select(t =>
+            {
+                var latestComment = t.Comments
+                    .OrderByDescending(c => c.CreatedAtUtc)
+                    .FirstOrDefault();
+
+                var hasComment = latestComment is not null;
+
+                var label = t.Status switch
+                {
+                    TicketStatus.Open => hasComment ? "Ticket updated" : "New ticket created",
+                    TicketStatus.InProgress => "Ticket updated",
+                    TicketStatus.Resolved => "Ticket resolved",
+                    TicketStatus.Closed => "Ticket closed",
+                    _ => "Ticket updated"
+                };
+
+                var authorName = hasComment
+                    ? (latestComment!.Author.UserName ?? latestComment.Author.Email ?? "-")
+                    : (t.Author.UserName ?? t.Author.Email ?? "-");
+
+                var eventTimeUtc = hasComment
+                    ? latestComment!.CreatedAtUtc
+                    : t.Status == TicketStatus.Open ? t.CreatedAtUtc : t.UpdatedAtUtc;
+
+                return new DashboardRecentActivityViewModel
+                {
+                    AuthorName = authorName,
+                    Label = label,
+                    TicketId = t.Id,
+                    EventTimeUtc = eventTimeUtc
+                };
+            })
+            .OrderByDescending(a => a.EventTimeUtc)
+            .Take(5)
+            .ToList();
 
         var recentTickets = await _context.Tickets
             .AsNoTracking()
@@ -46,6 +101,14 @@ public class DashboardController(ApplicationDbContext context) : Controller
             OpenCount = openCount,
             InProgressCount = inProgressCount,
             ResolvedCount = resolvedCount,
+            HighPriorityCount = highPriorityCount,
+            PriorityBreakdown =
+            [
+                new DashboardPriorityBucketViewModel { Label = "Low", Count = lowPriorityCount },
+                new DashboardPriorityBucketViewModel { Label = "Medium", Count = mediumPriorityCount },
+                new DashboardPriorityBucketViewModel { Label = "High", Count = highPriorityBucketCount }
+            ],
+            RecentActivities = recentActivities,
             RecentTickets = recentTickets
         });
     }

--- a/DeskNin/Controllers/SettingsController.cs
+++ b/DeskNin/Controllers/SettingsController.cs
@@ -1,18 +1,57 @@
+using DeskNin.Data;
+using DeskNin.Models;
 using DeskNin.ViewModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace DeskNin.Controllers;
 
 [Authorize]
-public class SettingsController : Controller
+public class SettingsController(ApplicationDbContext context, UserManager<IdentityUser> userManager) : Controller
 {
-    private readonly UserManager<IdentityUser> _userManager;
+    private readonly ApplicationDbContext _context = context;
+    private readonly UserManager<IdentityUser> _userManager = userManager;
 
-    public SettingsController(UserManager<IdentityUser> userManager)
+    [HttpGet]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
     {
-        _userManager = userManager;
+        var row = await _context.Settings
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Key == SettingKeys.EmailNotificationsEnabled, cancellationToken);
+
+        return View(new SettingsIndexViewModel
+        {
+            EmailNotificationsEnabled = SettingValue.AsBool(row?.Value),
+            CanManageSystemEmail = User.IsInRole("Admin")
+        });
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> SaveEmailNotifications(bool emailNotificationsEnabled, CancellationToken cancellationToken)
+    {
+        var row = await _context.Settings
+            .FirstOrDefaultAsync(s => s.Key == SettingKeys.EmailNotificationsEnabled, cancellationToken);
+
+        if (row == null)
+        {
+            _context.Settings.Add(new Setting
+            {
+                Key = SettingKeys.EmailNotificationsEnabled,
+                Value = SettingValue.FromBool(emailNotificationsEnabled)
+            });
+        }
+        else
+        {
+            row.Value = SettingValue.FromBool(emailNotificationsEnabled);
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+        TempData["SettingsSaved"] = true;
+        return RedirectToAction(nameof(Index));
     }
 
     [HttpGet]

--- a/DeskNin/Controllers/TeamController.cs
+++ b/DeskNin/Controllers/TeamController.cs
@@ -161,11 +161,28 @@ public class TeamController : Controller
 
         var code = await _userManager.GeneratePasswordResetTokenAsync(user);
         var encodedCode = WebEncoders.Base64UrlEncode(System.Text.Encoding.UTF8.GetBytes(code));
-        var resetUrl = Url.Page(
-            "/Account/ResetPassword",
-            pageHandler: null,
-            values: new { area = "Identity", code = encodedCode, email = user.Email },
-            protocol: Request.Scheme);
+        string? resetUrl;
+        try
+        {
+            resetUrl = Url.Page(
+                "/Account/ResetPassword",
+                pageHandler: null,
+                values: new { area = "Identity", code = encodedCode, email = user.Email },
+                protocol: Request.Scheme);
+        }
+        catch
+        {
+            resetUrl = null;
+        }
+
+        if (string.IsNullOrWhiteSpace(resetUrl))
+        {
+            var scheme = string.IsNullOrWhiteSpace(Request.Scheme) ? "https" : Request.Scheme;
+            var host = Request.Host.HasValue ? Request.Host.Value : "localhost";
+            resetUrl =
+                $"{scheme}://{host}/Identity/Account/ResetPassword?code={Uri.EscapeDataString(encodedCode)}&email={Uri.EscapeDataString(user.Email)}";
+        }
+
         var htmlBody = _emailTemplateService.BuildOnboardingBody(user.Email, resetUrl ?? string.Empty);
 
         try

--- a/DeskNin/Controllers/TeamController.cs
+++ b/DeskNin/Controllers/TeamController.cs
@@ -1,4 +1,5 @@
 using DeskNin.Data;
+using DeskNin.Services;
 using DeskNin.ViewModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -13,12 +14,25 @@ public class TeamController : Controller
     private readonly ApplicationDbContext _context;
     private readonly UserManager<IdentityUser> _userManager;
     private readonly RoleManager<IdentityRole> _roleManager;
+    private readonly IPasswordGenerator _passwordGenerator;
 
-    public TeamController(ApplicationDbContext context, UserManager<IdentityUser> userManager, RoleManager<IdentityRole> roleManager)
+    public TeamController(
+        ApplicationDbContext context,
+        UserManager<IdentityUser> userManager,
+        RoleManager<IdentityRole> roleManager,
+        IPasswordGenerator passwordGenerator)
     {
         _context = context;
         _userManager = userManager;
         _roleManager = roleManager;
+        _passwordGenerator = passwordGenerator;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GeneratePassword()
+    {
+        var password = await _passwordGenerator.GenerateIdentityCompliantPasswordAsync();
+        return Json(new { password });
     }
 
     public async Task<IActionResult> Index()

--- a/DeskNin/Controllers/TeamController.cs
+++ b/DeskNin/Controllers/TeamController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace DeskNin.Controllers;
 
@@ -15,17 +16,29 @@ public class TeamController : Controller
     private readonly UserManager<IdentityUser> _userManager;
     private readonly RoleManager<IdentityRole> _roleManager;
     private readonly IPasswordGenerator _passwordGenerator;
+    private readonly IAppSettingsService _appSettingsService;
+    private readonly IAppEmailSender _appEmailSender;
+    private readonly IEmailTemplateService _emailTemplateService;
+    private readonly ILogger<TeamController> _logger;
 
     public TeamController(
         ApplicationDbContext context,
         UserManager<IdentityUser> userManager,
         RoleManager<IdentityRole> roleManager,
-        IPasswordGenerator passwordGenerator)
+        IPasswordGenerator passwordGenerator,
+        IAppSettingsService appSettingsService,
+        IAppEmailSender appEmailSender,
+        IEmailTemplateService emailTemplateService,
+        ILogger<TeamController> logger)
     {
         _context = context;
         _userManager = userManager;
         _roleManager = roleManager;
         _passwordGenerator = passwordGenerator;
+        _appSettingsService = appSettingsService;
+        _appEmailSender = appEmailSender;
+        _emailTemplateService = emailTemplateService;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -66,7 +79,8 @@ public class TeamController : Controller
         var user = new IdentityUser
         {
             UserName = form.Username,
-            Email = form.Email
+            Email = form.Email,
+            EmailConfirmed = true
         };
         var result = await _userManager.CreateAsync(user, form.Password!);
         if (!result.Succeeded)
@@ -75,7 +89,19 @@ public class TeamController : Controller
             TempData["AddMemberError"] = msg;
             return RedirectToAction("Index");
         }
-        await _userManager.AddToRoleAsync(user, form.Role);
+        var roleResult = await _userManager.AddToRoleAsync(user, form.Role);
+        if (!roleResult.Succeeded)
+        {
+            var roleMsg = string.Join(" ", roleResult.Errors.Select(e => e.Description));
+            TempData["AddMemberError"] = string.IsNullOrWhiteSpace(roleMsg)
+                ? "Could not assign role to the new user."
+                : roleMsg;
+            return RedirectToAction("Index");
+        }
+
+        if (await _appSettingsService.IsEmailEnabledAsync())
+            await TrySendOnboardingEmailAsync(user);
+
         return RedirectToAction("Index");
     }
 
@@ -126,5 +152,32 @@ public class TeamController : Controller
         await _userManager.AddToRoleAsync(user, form.Role);
 
         return RedirectToAction("Index");
+    }
+
+    private async Task TrySendOnboardingEmailAsync(IdentityUser user)
+    {
+        if (string.IsNullOrWhiteSpace(user.Email))
+            return;
+
+        var code = await _userManager.GeneratePasswordResetTokenAsync(user);
+        var encodedCode = WebEncoders.Base64UrlEncode(System.Text.Encoding.UTF8.GetBytes(code));
+        var resetUrl = Url.Page(
+            "/Account/ResetPassword",
+            pageHandler: null,
+            values: new { area = "Identity", code = encodedCode, email = user.Email },
+            protocol: Request.Scheme);
+        var htmlBody = _emailTemplateService.BuildOnboardingBody(user.Email, resetUrl ?? string.Empty);
+
+        try
+        {
+            await _appEmailSender.SendEmailAsync(
+                user.Email,
+                "Set your DeskNin password",
+                htmlBody);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to send onboarding email for user {UserId}", user.Id);
+        }
     }
 }

--- a/DeskNin/Controllers/TicketsController.cs
+++ b/DeskNin/Controllers/TicketsController.cs
@@ -15,8 +15,14 @@ public class TicketsController(ApplicationDbContext context, UserManager<Identit
     private readonly ApplicationDbContext _context = context;
     private readonly UserManager<IdentityUser> _userManager = userManager;
 
-    public async Task<IActionResult> Index(TicketStatus? status = null)
+    [Authorize(Roles = "Admin,Technical")]
+    public async Task<IActionResult> Index(TicketStatus? status = null, bool assignedToMe = false)
     {
+        if (!Request.Query.ContainsKey("status"))
+            status = TicketStatus.Open;
+
+        var userId = GetCurrentUserId();
+
         var query = _context.Tickets
             .AsNoTracking()
             .Include(t => t.Author)
@@ -26,6 +32,14 @@ public class TicketsController(ApplicationDbContext context, UserManager<Identit
 
         if (status.HasValue)
             query = query.Where(t => t.Status == status.Value);
+
+        if (assignedToMe)
+        {
+            if (string.IsNullOrEmpty(userId))
+                return Forbid();
+
+            query = query.Where(t => t.AssignedTechnicianId == userId);
+        }
 
         query = query
             .OrderByDescending(t => t.Priority)
@@ -48,7 +62,51 @@ public class TicketsController(ApplicationDbContext context, UserManager<Identit
             })
             .ToListAsync();
 
-        return View(new TicketListViewModel { Tickets = tickets, SelectedStatus = status });
+        return View(new TicketListViewModel { Tickets = tickets, SelectedStatus = status, AssignedToMe = assignedToMe });
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> MyTickets(TicketStatus? status = null)
+    {
+        var userId = GetCurrentUserId();
+        if (string.IsNullOrEmpty(userId))
+            return Forbid();
+
+        var query = _context.Tickets
+            .AsNoTracking()
+            .Include(t => t.Author)
+            .Include(t => t.AssignedTechnician)
+            .Include(t => t.Comments)
+            .Where(t => t.AuthorId == userId);
+
+        if (status.HasValue)
+            query = query.Where(t => t.Status == status.Value);
+
+        var tickets = await query
+            .OrderByDescending(t => t.Priority)
+            .ThenByDescending(t => t.CreatedAtUtc)
+            .Select(t => new TicketItemViewModel
+            {
+                Id = t.Id,
+                Title = t.Title,
+                DescriptionPreview = t.Description.Length > 120 ? t.Description.Substring(0, 120) + "..." : t.Description,
+                Status = t.Status,
+                Priority = t.Priority,
+                AuthorName = t.Author.UserName ?? t.Author.Email ?? "-",
+                AssignedTechnicianId = t.AssignedTechnicianId,
+                AssignedTechnicianName = t.AssignedTechnician != null ? t.AssignedTechnician.UserName ?? t.AssignedTechnician.Email : null,
+                CreatedAtUtc = t.CreatedAtUtc,
+                UpdatedAtUtc = t.UpdatedAtUtc,
+                CommentCount = t.Comments.Count
+            })
+            .ToListAsync();
+
+        return View("MyTickets", new TicketListViewModel
+        {
+            Tickets = tickets,
+            SelectedStatus = status,
+            AssignedToMe = false
+        });
     }
 
     public IActionResult Create() => View(new TicketFormViewModel());

--- a/DeskNin/Controllers/TicketsController.cs
+++ b/DeskNin/Controllers/TicketsController.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using DeskNin.Data;
 using DeskNin.Models;
+using DeskNin.Services;
 using DeskNin.ViewModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -10,10 +11,16 @@ using Microsoft.EntityFrameworkCore;
 namespace DeskNin.Controllers;
 
 [Authorize]
-public class TicketsController(ApplicationDbContext context, UserManager<IdentityUser> userManager) : Controller
+public class TicketsController(
+    ApplicationDbContext context,
+    UserManager<IdentityUser> userManager,
+    ITicketNotificationService ticketNotificationService,
+    ILogger<TicketsController> logger) : Controller
 {
     private readonly ApplicationDbContext _context = context;
     private readonly UserManager<IdentityUser> _userManager = userManager;
+    private readonly ITicketNotificationService _ticketNotificationService = ticketNotificationService;
+    private readonly ILogger<TicketsController> _logger = logger;
 
     [Authorize(Roles = "Admin,Technical")]
     public async Task<IActionResult> Index(TicketStatus? status = null, bool assignedToMe = false)
@@ -229,6 +236,7 @@ public class TicketsController(ApplicationDbContext context, UserManager<Identit
         ticket.UpdatedAtUtc = DateTime.UtcNow;
 
         await _context.SaveChangesAsync();
+        await NotifyUpdateAsync(ticket, "details updated", "Title/description or priority was edited.");
         return RedirectToAction(nameof(Details), new { id = ticket.Id });
     }
 
@@ -244,20 +252,27 @@ public class TicketsController(ApplicationDbContext context, UserManager<Identit
         if (!ticket.CanManageWorkflow)
             return RedirectToAction(nameof(Details), new { id });
 
+        string assignmentSummary;
         if (!string.IsNullOrWhiteSpace(assignedTechnicianId))
         {
-            var exists = await _context.Users.AnyAsync(u => u.Id == assignedTechnicianId);
-            if (!exists)
+            var assignee = await _context.Users
+                .AsNoTracking()
+                .FirstOrDefaultAsync(u => u.Id == assignedTechnicianId);
+            if (assignee == null)
                 return NotFound();
             ticket.AssignedTechnicianId = assignedTechnicianId;
+            var assigneeName = assignee.UserName ?? assignee.Email ?? assignee.Id;
+            assignmentSummary = $"Assigned technician: {assigneeName}.";
         }
         else
         {
             ticket.AssignedTechnicianId = null;
+            assignmentSummary = "Ticket is now unassigned.";
         }
 
         ticket.UpdatedAtUtc = DateTime.UtcNow;
         await _context.SaveChangesAsync();
+        await NotifyUpdateAsync(ticket, "assignment updated", assignmentSummary);
         return RedirectToAction(nameof(Details), new { id });
     }
 
@@ -275,6 +290,7 @@ public class TicketsController(ApplicationDbContext context, UserManager<Identit
 
         ticket.ChangeStatus(status, DateTime.UtcNow);
         await _context.SaveChangesAsync();
+        await NotifyUpdateAsync(ticket, "status updated", $"Status changed to {status}.");
 
         return RedirectToAction(nameof(Details), new { id });
     }
@@ -294,6 +310,7 @@ public class TicketsController(ApplicationDbContext context, UserManager<Identit
         ticket.Priority = priority;
         ticket.UpdatedAtUtc = DateTime.UtcNow;
         await _context.SaveChangesAsync();
+        await NotifyUpdateAsync(ticket, "priority updated", $"Priority changed to {priority}.");
 
         return RedirectToAction(nameof(Details), new { id });
     }
@@ -323,6 +340,7 @@ public class TicketsController(ApplicationDbContext context, UserManager<Identit
         ticket.UpdatedAtUtc = DateTime.UtcNow;
 
         await _context.SaveChangesAsync();
+        await NotifyUpdateAsync(ticket, "new comment", "A new comment was added to this ticket.");
         return RedirectToAction(nameof(Details), new { id = form.TicketId });
     }
 
@@ -354,5 +372,21 @@ public class TicketsController(ApplicationDbContext context, UserManager<Identit
                 Name = u.UserName ?? u.Email ?? u.Id
             })
             .ToList();
+    }
+
+    private async Task NotifyUpdateAsync(Ticket ticket, string eventLabel, string changeSummary)
+    {
+        var actorId = GetCurrentUserId();
+        if (string.IsNullOrWhiteSpace(actorId))
+            return;
+
+        try
+        {
+            await _ticketNotificationService.NotifyTicketUpdatedAsync(ticket, actorId, eventLabel, changeSummary);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to notify ticket update for ticket {TicketId}", ticket.Id);
+        }
     }
 }

--- a/DeskNin/Data/ApplicationDbContext.cs
+++ b/DeskNin/Data/ApplicationDbContext.cs
@@ -11,6 +11,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
 {
     public DbSet<Ticket> Tickets { get; set; }
     public DbSet<TicketComment> TicketComments { get; set; }
+    public DbSet<Setting> Settings { get; set; }
 
     /// <inheritdoc />
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -84,6 +85,19 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
                 .OnDelete(DeleteBehavior.Restrict);
 
             entity.HasIndex(c => new { c.TicketId, c.CreatedAtUtc });
+        });
+
+        modelBuilder.Entity<Setting>(entity =>
+        {
+            entity.HasKey(e => e.Key);
+            entity.Property(e => e.Key).HasMaxLength(128).IsRequired();
+            entity.Property(e => e.Value).HasMaxLength(4000).IsRequired();
+
+            entity.HasData(new Setting
+            {
+                Key = SettingKeys.EmailNotificationsEnabled,
+                Value = SettingValue.FromBool(false)
+            });
         });
     }
 

--- a/DeskNin/Data/ApplicationDbContext.cs
+++ b/DeskNin/Data/ApplicationDbContext.cs
@@ -29,18 +29,21 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
             new IdentityRole
             {
                 Id = "ROLE_ADMIN",
+                ConcurrencyStamp = "ed8b48f3-261a-465c-a340-0fbbd3c5c8e4",
                 Name = "Admin",
                 NormalizedName = "ADMIN"
             },
             new IdentityRole
             {
                 Id = "ROLE_TECHNICAL",
+                ConcurrencyStamp = "f30c6299-89f3-49a3-92ed-d9105a69be0a",
                 Name = "Technical",
                 NormalizedName = "TECHNICAL"
             },
             new IdentityRole
             {
                 Id = "ROLE_USER",
+                ConcurrencyStamp = "86bf3845-f7bf-4488-b442-5035f4ec4ff7",
                 Name = "User",
                 NormalizedName = "USER"
             }

--- a/DeskNin/Data/Migrations/20260328030754_SettingsKeyValue.Designer.cs
+++ b/DeskNin/Data/Migrations/20260328030754_SettingsKeyValue.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DeskNin.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DeskNin.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260328030754_SettingsKeyValue")]
+    partial class SettingsKeyValue
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DeskNin/Data/Migrations/20260328030754_SettingsKeyValue.cs
+++ b/DeskNin/Data/Migrations/20260328030754_SettingsKeyValue.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DeskNin.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SettingsKeyValue : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "settings",
+                columns: table => new
+                {
+                    key = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    value = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_settings", x => x.key);
+                });
+
+            migrationBuilder.InsertData(
+                table: "settings",
+                columns: new[] { "key", "value" },
+                values: new object[] { "EmailNotificationsEnabled", "false" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "settings");
+        }
+    }
+}

--- a/DeskNin/Models/Setting.cs
+++ b/DeskNin/Models/Setting.cs
@@ -1,0 +1,8 @@
+namespace DeskNin.Models;
+
+public sealed class Setting
+{
+    public string Key { get; set; } = string.Empty;
+
+    public string Value { get; set; } = string.Empty;
+}

--- a/DeskNin/Models/SettingKeys.cs
+++ b/DeskNin/Models/SettingKeys.cs
@@ -1,0 +1,6 @@
+namespace DeskNin.Models;
+
+public static class SettingKeys
+{
+    public const string EmailNotificationsEnabled = nameof(EmailNotificationsEnabled);
+}

--- a/DeskNin/Models/SettingValue.cs
+++ b/DeskNin/Models/SettingValue.cs
@@ -1,0 +1,9 @@
+namespace DeskNin.Models;
+
+public static class SettingValue
+{
+    public static bool AsBool(string? stored) =>
+        bool.TryParse(stored, out var b) && b;
+
+    public static string FromBool(bool value) => value ? "true" : "false";
+}

--- a/DeskNin/Program.cs
+++ b/DeskNin/Program.cs
@@ -13,12 +13,23 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
         .UseSnakeCaseNamingConvention());
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
-builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = false)
+builder.Services.AddDefaultIdentity<IdentityUser>(options =>
+    {
+        options.SignIn.RequireConfirmedAccount = false;
+        options.User.RequireUniqueEmail = true;
+        options.User.AllowedUserNameCharacters =
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+ ";
+    })
     .AddRoles<IdentityRole>()
     .AddEntityFrameworkStores<ApplicationDbContext>();
 builder.Services.AddControllersWithViews();
 
 builder.Services.AddScoped<IPasswordGenerator, IdentityPasswordGenerator>();
+builder.Services.AddScoped<IAppSettingsService, AppSettingsService>();
+builder.Services.AddScoped<IEmailTemplateService, EmailTemplateService>();
+builder.Services.AddScoped<ITicketNotificationService, TicketNotificationService>();
+builder.Services.Configure<ResendOptions>(builder.Configuration.GetSection(ResendOptions.SectionName));
+builder.Services.AddHttpClient<IAppEmailSender, ResendEmailSender>();
 
 var app = builder.Build();
 

--- a/DeskNin/Program.cs
+++ b/DeskNin/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using DeskNin.Data;
+using DeskNin.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,6 +17,8 @@ builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.Requ
     .AddRoles<IdentityRole>()
     .AddEntityFrameworkStores<ApplicationDbContext>();
 builder.Services.AddControllersWithViews();
+
+builder.Services.AddScoped<IPasswordGenerator, IdentityPasswordGenerator>();
 
 var app = builder.Build();
 

--- a/DeskNin/Services/AppSettingsService.cs
+++ b/DeskNin/Services/AppSettingsService.cs
@@ -1,0 +1,19 @@
+using DeskNin.Data;
+using DeskNin.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DeskNin.Services;
+
+public class AppSettingsService(ApplicationDbContext context) : IAppSettingsService
+{
+    private readonly ApplicationDbContext _context = context;
+
+    public async Task<bool> IsEmailEnabledAsync(CancellationToken cancellationToken = default)
+    {
+        var row = await _context.Settings
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Key == SettingKeys.EmailNotificationsEnabled, cancellationToken);
+
+        return SettingValue.AsBool(row?.Value);
+    }
+}

--- a/DeskNin/Services/EmailTemplateService.cs
+++ b/DeskNin/Services/EmailTemplateService.cs
@@ -1,0 +1,103 @@
+using System.Text.Encodings.Web;
+using Microsoft.Extensions.Options;
+
+namespace DeskNin.Services;
+
+public sealed class EmailTemplateService(IOptions<ResendOptions> resendOptions) : IEmailTemplateService
+{
+    private static readonly HtmlEncoder Encoder = HtmlEncoder.Default;
+    private readonly ResendOptions _resendOptions = resendOptions.Value;
+
+    public string BuildTicketUpdateBody(
+        string eventLabel,
+        int ticketId,
+        string ticketTitle,
+        string actorName,
+        string changeSummary,
+        string? assigneeName)
+    {
+        var assigneeRow = string.IsNullOrWhiteSpace(assigneeName)
+            ? string.Empty
+            : $"<tr><td style='padding:6px 0;color:#64748B;font-size:14px;'>Assigned to</td><td style='padding:6px 0;color:#0F172A;font-size:14px;font-weight:600;text-align:right;'>{Encode(assigneeName)}</td></tr>";
+
+        var content = $@"
+            <p style='margin:0 0 16px 0;color:#334155;font-size:14px;'>A ticket has been updated in DeskNin.</p>
+            <table role='presentation' width='100%' cellspacing='0' cellpadding='0' style='margin:0 0 16px 0;border-collapse:collapse;'>
+                <tr><td style='padding:6px 0;color:#64748B;font-size:14px;'>Event</td><td style='padding:6px 0;color:#0F172A;font-size:14px;font-weight:600;text-align:right;'>{Encode(eventLabel)}</td></tr>
+                <tr><td style='padding:6px 0;color:#64748B;font-size:14px;'>Ticket</td><td style='padding:6px 0;color:#0F172A;font-size:14px;font-weight:600;text-align:right;'>#{ticketId} - {Encode(ticketTitle)}</td></tr>
+                <tr><td style='padding:6px 0;color:#64748B;font-size:14px;'>Updated by</td><td style='padding:6px 0;color:#0F172A;font-size:14px;font-weight:600;text-align:right;'>{Encode(actorName)}</td></tr>
+                {assigneeRow}
+            </table>
+            <div style='background:#F8FAFC;border:1px solid #E2E8F0;border-radius:10px;padding:12px 14px;color:#334155;font-size:14px;line-height:1.5;'>
+                <strong style='color:#0F172A;'>Change summary:</strong><br/>{Encode(changeSummary)}
+            </div>";
+
+        return Wrap("Ticket update", content);
+    }
+
+    public string BuildOnboardingBody(string userEmail, string resetPasswordUrl)
+    {
+        var content = $@"
+            <p style='margin:0 0 16px 0;color:#334155;font-size:14px;'>Your DeskNin account has been created.</p>
+            <table role='presentation' width='100%' cellspacing='0' cellpadding='0' style='margin:0 0 16px 0;border-collapse:collapse;'>
+                <tr><td style='padding:6px 0;color:#64748B;font-size:14px;'>Email</td><td style='padding:6px 0;color:#0F172A;font-size:14px;font-weight:600;text-align:right;'>{Encode(userEmail)}</td></tr>
+            </table>
+            <p style='margin:0 0 16px 0;color:#334155;font-size:14px;'>Please create your password to access DeskNin.</p>
+            <a href='{Encode(resetPasswordUrl)}' style='display:inline-block;background:#2563EB;color:#FFFFFF;text-decoration:none;padding:10px 16px;border-radius:8px;font-size:14px;font-weight:600;'>Set password</a>";
+
+        return Wrap("Welcome to DeskNin", content);
+    }
+
+    public string BuildForgotPasswordBody(string resetUrl)
+    {
+        var content = $@"
+            <p style='margin:0 0 16px 0;color:#334155;font-size:14px;'>You requested a password reset for your DeskNin account.</p>
+            <a href='{Encode(resetUrl)}' style='display:inline-block;background:#2563EB;color:#FFFFFF;text-decoration:none;padding:10px 16px;border-radius:8px;font-size:14px;font-weight:600;'>Reset password</a>
+            <p style='margin:16px 0 0 0;color:#64748B;font-size:13px;'>If you did not request this, you can safely ignore this email.</p>";
+
+        return Wrap("Password reset", content);
+    }
+
+    private string Wrap(string heading, string innerHtml)
+    {
+        var brandBlock =
+            "<div style='font:700 20px Inter,Segoe UI,Arial,sans-serif;line-height:1;'>" +
+            "<span style='color:#E2E8F0;'>Desk</span>" +
+            "<span style='color:#60A5FA;'>Nin</span>" +
+            "</div>";
+
+        return $@"
+<!doctype html>
+<html>
+<body style='margin:0;padding:0;background:#F1F5F9;font-family:Inter,Segoe UI,Arial,sans-serif;'>
+    <table role='presentation' width='100%' cellspacing='0' cellpadding='0' style='padding:24px 12px;'>
+        <tr>
+            <td align='center'>
+                <table role='presentation' width='100%' cellspacing='0' cellpadding='0' style='max-width:620px;background:#FFFFFF;border:1px solid #E2E8F0;border-radius:14px;overflow:hidden;'>
+                    <tr>
+                        <td style='background:#0F172A;padding:18px 20px;'>
+                            {brandBlock}
+                            <div style='color:#CBD5E1;font-size:12px;margin-top:2px;'>Ticket management system</div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style='padding:22px 20px;'>
+                            <h2 style='margin:0 0 16px 0;color:#0F172A;font-size:18px;'>{Encode(heading)}</h2>
+                            {innerHtml}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style='border-top:1px solid #E2E8F0;padding:12px 20px;color:#64748B;font-size:12px;'>
+                            This message was sent by DeskNin.
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>";
+    }
+
+    private static string Encode(string value) => Encoder.Encode(value);
+}

--- a/DeskNin/Services/IAppEmailSender.cs
+++ b/DeskNin/Services/IAppEmailSender.cs
@@ -1,0 +1,6 @@
+namespace DeskNin.Services;
+
+public interface IAppEmailSender
+{
+    Task SendEmailAsync(string toEmail, string subject, string htmlBody, CancellationToken cancellationToken = default);
+}

--- a/DeskNin/Services/IAppSettingsService.cs
+++ b/DeskNin/Services/IAppSettingsService.cs
@@ -1,0 +1,6 @@
+namespace DeskNin.Services;
+
+public interface IAppSettingsService
+{
+    Task<bool> IsEmailEnabledAsync(CancellationToken cancellationToken = default);
+}

--- a/DeskNin/Services/IEmailTemplateService.cs
+++ b/DeskNin/Services/IEmailTemplateService.cs
@@ -1,0 +1,16 @@
+namespace DeskNin.Services;
+
+public interface IEmailTemplateService
+{
+    string BuildTicketUpdateBody(
+        string eventLabel,
+        int ticketId,
+        string ticketTitle,
+        string actorName,
+        string changeSummary,
+        string? assigneeName);
+
+    string BuildOnboardingBody(string userEmail, string resetPasswordUrl);
+
+    string BuildForgotPasswordBody(string resetUrl);
+}

--- a/DeskNin/Services/IPasswordGenerator.cs
+++ b/DeskNin/Services/IPasswordGenerator.cs
@@ -1,0 +1,7 @@
+namespace DeskNin.Services;
+
+public interface IPasswordGenerator
+{
+    Task<string> GenerateIdentityCompliantPasswordAsync(CancellationToken ct = default);
+}
+

--- a/DeskNin/Services/ITicketNotificationService.cs
+++ b/DeskNin/Services/ITicketNotificationService.cs
@@ -1,0 +1,13 @@
+using DeskNin.Models;
+
+namespace DeskNin.Services;
+
+public interface ITicketNotificationService
+{
+    Task NotifyTicketUpdatedAsync(
+        Ticket ticket,
+        string actorUserId,
+        string eventLabel,
+        string changeSummary,
+        CancellationToken cancellationToken = default);
+}

--- a/DeskNin/Services/IdentityPasswordGenerator.cs
+++ b/DeskNin/Services/IdentityPasswordGenerator.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using System.Security.Cryptography;
+
+namespace DeskNin.Services;
+
+public sealed class IdentityPasswordGenerator(
+    UserManager<IdentityUser> userManager,
+    IOptions<IdentityOptions> identityOptions) : IPasswordGenerator
+{
+    private readonly UserManager<IdentityUser> _userManager = userManager;
+    private readonly IOptions<IdentityOptions> _identityOptions = identityOptions;
+
+    public async Task<string> GenerateIdentityCompliantPasswordAsync(CancellationToken ct = default)
+    {
+        static char Pick(string set) => set[RandomNumberGenerator.GetInt32(set.Length)];
+
+        static void Shuffle(IList<char> chars)
+        {
+            for (var i = chars.Count - 1; i > 0; i--)
+            {
+                var j = RandomNumberGenerator.GetInt32(i + 1);
+                (chars[i], chars[j]) = (chars[j], chars[i]);
+            }
+        }
+
+        async Task<bool> IsValidAsync(string password)
+        {
+            var dummyUser = new IdentityUser { UserName = "temp", Email = "temp@example.com" };
+            foreach (var v in _userManager.PasswordValidators)
+            {
+                var res = await v.ValidateAsync(_userManager, dummyUser, password);
+                if (!res.Succeeded)
+                    return false;
+            }
+            return true;
+        }
+
+        var p = _identityOptions.Value.Password;
+        var length = Math.Max(12, p.RequiredLength);
+        var unique = Math.Max(1, p.RequiredUniqueChars);
+
+        const string Upper = "ABCDEFGHJKLMNPQRSTUVWXYZ";
+        const string Lower = "abcdefghjkmnpqrstuvwxyz";
+        const string Digits = "23456789";
+        const string Special = "!@#$%";
+
+        var requiredSets = new List<string>(4);
+        if (p.RequireUppercase) requiredSets.Add(Upper);
+        if (p.RequireLowercase) requiredSets.Add(Lower);
+        if (p.RequireDigit) requiredSets.Add(Digits);
+        if (p.RequireNonAlphanumeric) requiredSets.Add(Special);
+        if (requiredSets.Count == 0) requiredSets.Add(Upper + Lower + Digits);
+
+        var all = string.Concat(requiredSets.Distinct());
+
+        for (var attempt = 0; attempt < 40; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var chars = new List<char>(length);
+            foreach (var set in requiredSets)
+                chars.Add(Pick(set));
+
+            while (chars.Count < length)
+                chars.Add(Pick(all));
+
+            Shuffle(chars);
+
+            if (chars.Distinct().Count() < unique)
+                continue;
+
+            var candidate = new string(chars.ToArray());
+            if (await IsValidAsync(candidate))
+                return candidate;
+        }
+
+        // Extremely unlikely fallback.
+        return Convert.ToBase64String(RandomNumberGenerator.GetBytes(18)) + "Aa1!";
+    }
+}
+

--- a/DeskNin/Services/ResendEmailSender.cs
+++ b/DeskNin/Services/ResendEmailSender.cs
@@ -1,0 +1,63 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace DeskNin.Services;
+
+public sealed class ResendEmailSender(
+    HttpClient httpClient,
+    IOptions<ResendOptions> options) : IAppEmailSender
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _httpClient = httpClient;
+    private readonly ResendOptions _options = options.Value;
+
+    public async Task SendEmailAsync(string toEmail, string subject, string htmlBody, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(_options.ApiKey))
+            throw new InvalidOperationException("Resend API key is not configured.");
+        if (string.IsNullOrWhiteSpace(_options.FromEmail))
+            throw new InvalidOperationException("Resend from e-mail is not configured.");
+        if (!IsValidFromEmail(_options.FromEmail))
+            throw new InvalidOperationException(
+                $"Resend from e-mail is invalid for production sending: '{_options.FromEmail}'. Use a verified domain sender (e.g. no-reply@your-domain.com).");
+
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _options.ApiKey);
+
+        var payload = new
+        {
+            from = _options.FromEmail,
+            to = new[] { toEmail },
+            subject,
+            html = htmlBody,
+            reply_to = string.IsNullOrWhiteSpace(_options.ReplyToEmail) ? null : _options.ReplyToEmail
+        };
+
+        var json = JsonSerializer.Serialize(payload, JsonOptions);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://api.resend.com/emails")
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new InvalidOperationException($"Resend send failed with status {(int)response.StatusCode}: {body}");
+        }
+    }
+
+    private static bool IsValidFromEmail(string fromEmail)
+    {
+        var normalized = fromEmail.Trim().ToLowerInvariant();
+        if (normalized == "admin@desknin.local")
+            return false;
+        if (normalized.EndsWith("@desknin.local", StringComparison.Ordinal))
+            return false;
+        if (normalized.Contains(".local", StringComparison.Ordinal))
+            return false;
+        return normalized.Contains('@');
+    }
+}

--- a/DeskNin/Services/ResendOptions.cs
+++ b/DeskNin/Services/ResendOptions.cs
@@ -1,0 +1,14 @@
+namespace DeskNin.Services;
+
+public sealed class ResendOptions
+{
+    public const string SectionName = "Resend";
+
+    public string ApiKey { get; set; } = string.Empty;
+
+    public string FromEmail { get; set; } = string.Empty;
+
+    public string? ReplyToEmail { get; set; }
+
+    public string? LogoUrl { get; set; }
+}

--- a/DeskNin/Services/TicketNotificationService.cs
+++ b/DeskNin/Services/TicketNotificationService.cs
@@ -1,0 +1,75 @@
+using DeskNin.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace DeskNin.Services;
+
+public class TicketNotificationService(
+    UserManager<IdentityUser> userManager,
+    IAppSettingsService appSettingsService,
+    IAppEmailSender emailSender,
+    IEmailTemplateService emailTemplateService,
+    ILogger<TicketNotificationService> logger) : ITicketNotificationService
+{
+    private readonly UserManager<IdentityUser> _userManager = userManager;
+    private readonly IAppSettingsService _appSettingsService = appSettingsService;
+    private readonly IAppEmailSender _emailSender = emailSender;
+    private readonly IEmailTemplateService _emailTemplateService = emailTemplateService;
+    private readonly ILogger<TicketNotificationService> _logger = logger;
+
+    public async Task NotifyTicketUpdatedAsync(
+        Ticket ticket,
+        string actorUserId,
+        string eventLabel,
+        string changeSummary,
+        CancellationToken cancellationToken = default)
+    {
+        if (!await _appSettingsService.IsEmailEnabledAsync(cancellationToken))
+            return;
+
+        var actor = await _userManager.FindByIdAsync(actorUserId);
+        var actorName = actor?.UserName ?? actor?.Email ?? "A user";
+
+        var recipients = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrWhiteSpace(ticket.AuthorId))
+        {
+            var author = await _userManager.FindByIdAsync(ticket.AuthorId);
+            if (!string.IsNullOrWhiteSpace(author?.Email))
+                recipients.Add(author.Email);
+        }
+
+        string? assigneeName = null;
+        if (!string.IsNullOrWhiteSpace(ticket.AssignedTechnicianId))
+        {
+            var assignee = await _userManager.FindByIdAsync(ticket.AssignedTechnicianId);
+            assigneeName = assignee?.UserName ?? assignee?.Email;
+            if (!string.IsNullOrWhiteSpace(assignee?.Email))
+                recipients.Add(assignee.Email);
+        }
+
+        if (recipients.Count == 0)
+            return;
+
+        var safeTitle = ticket.Title.Length > 80 ? $"{ticket.Title[..77]}..." : ticket.Title;
+        var subject = $"[DeskNin] {eventLabel}: {safeTitle} (#{ticket.Id})";
+        var htmlBody = _emailTemplateService.BuildTicketUpdateBody(
+            eventLabel,
+            ticket.Id,
+            ticket.Title,
+            actorName,
+            changeSummary,
+            assigneeName);
+
+        foreach (var email in recipients)
+        {
+            try
+            {
+                await _emailSender.SendEmailAsync(email, subject, htmlBody, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to send ticket update email to {Email}", email);
+            }
+        }
+    }
+}

--- a/DeskNin/ViewModels/DashboardViewModel.cs
+++ b/DeskNin/ViewModels/DashboardViewModel.cs
@@ -5,5 +5,38 @@ public sealed class DashboardViewModel
     public int OpenCount { get; set; }
     public int InProgressCount { get; set; }
     public int ResolvedCount { get; set; }
+
+    public int HighPriorityCount { get; set; }
+
+    public List<DashboardPriorityBucketViewModel> PriorityBreakdown { get; set; } = [];
+
+    public List<DashboardRecentActivityViewModel> RecentActivities { get; set; } = [];
+
     public List<TicketItemViewModel> RecentTickets { get; set; } = [];
+}
+
+public sealed class DashboardPriorityBucketViewModel
+{
+    public string Label { get; set; } = string.Empty;
+    public int Count { get; set; }
+}
+
+public sealed class DashboardRecentActivityViewModel
+{
+    public string AuthorName { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+    public int TicketId { get; set; }
+    public DateTime EventTimeUtc { get; set; }
+}
+
+public sealed class DashboardMetricCardViewModel
+{
+    public string Label { get; set; } = string.Empty;
+    public int Count { get; set; }
+
+    // Bootstrap background utility class for the small dot/icon (e.g. "bg-primary").
+    public string AccentCssClass { get; set; } = "bg-primary";
+
+    // Controls which right-side icon is rendered in the metric card.
+    public string IconKind { get; set; } = string.Empty;
 }

--- a/DeskNin/ViewModels/SettingsIndexViewModel.cs
+++ b/DeskNin/ViewModels/SettingsIndexViewModel.cs
@@ -1,0 +1,8 @@
+namespace DeskNin.ViewModels;
+
+public sealed class SettingsIndexViewModel
+{
+    public bool EmailNotificationsEnabled { get; set; }
+
+    public bool CanManageSystemEmail { get; set; }
+}

--- a/DeskNin/ViewModels/TicketListViewModel.cs
+++ b/DeskNin/ViewModels/TicketListViewModel.cs
@@ -6,4 +6,5 @@ public sealed class TicketListViewModel
 {
     public List<TicketItemViewModel> Tickets { get; set; } = [];
     public TicketStatus? SelectedStatus { get; set; }
+    public bool AssignedToMe { get; set; }
 }

--- a/DeskNin/Views/Dashboard/Index.cshtml
+++ b/DeskNin/Views/Dashboard/Index.cshtml
@@ -7,73 +7,53 @@
 <div>
     <header class="mb-4">
         <h1 class="h3 fw-bold mb-1">Dashboard</h1>
-        <p class="text-body-secondary small mb-0">Tickets overview</p>
+        <p class="text-body-secondary small mb-0">Ticket overview</p>
     </header>
+
+    @{
+        var openCard = new DeskNin.ViewModels.DashboardMetricCardViewModel
+        {
+            Label = "Open",
+            Count = Model.OpenCount,
+            AccentCssClass = "bg-primary",
+            IconKind = "open"
+        };
+
+        var inProgressCard = new DeskNin.ViewModels.DashboardMetricCardViewModel
+        {
+            Label = "In progress",
+            Count = Model.InProgressCount,
+            AccentCssClass = "bg-warning",
+            IconKind = "in_progress"
+        };
+
+        var resolvedCard = new DeskNin.ViewModels.DashboardMetricCardViewModel
+        {
+            Label = "Resolved",
+            Count = Model.ResolvedCount,
+            AccentCssClass = "bg-success",
+            IconKind = "resolved"
+        };
+    }
 
     <div class="row g-3 mb-4">
         <div class="col-12 col-md-4">
-            <div class="card h-100 border-0 shadow-sm rounded-3">
-                <div class="card-body">
-                    <div class="d-flex align-items-center justify-content-between mb-2">
-                        <span class="d-flex align-items-center gap-2 small fw-medium">
-                            <span class="rounded-circle bg-primary" style="width: 8px; height: 8px;"></span>
-                            Open
-                        </span>
-                    </div>
-                    <p class="h4 fw-bold mb-0">@Model.OpenCount</p>
-                </div>
-            </div>
+            <partial name="_DashboardMetricCard" model="openCard" />
         </div>
         <div class="col-12 col-md-4">
-            <div class="card h-100 border-0 shadow-sm rounded-3">
-                <div class="card-body">
-                    <div class="d-flex align-items-center justify-content-between mb-2">
-                        <span class="d-flex align-items-center gap-2 small fw-medium">
-                            <span class="rounded-circle bg-warning" style="width: 8px; height: 8px;"></span>
-                            In progress
-                        </span>
-                    </div>
-                    <p class="h4 fw-bold mb-0">@Model.InProgressCount</p>
-                </div>
-            </div>
+            <partial name="_DashboardMetricCard" model="inProgressCard" />
         </div>
         <div class="col-12 col-md-4">
-            <div class="card h-100 border-0 shadow-sm rounded-3">
-                <div class="card-body">
-                    <div class="d-flex align-items-center justify-content-between mb-2">
-                        <span class="d-flex align-items-center gap-2 small fw-medium">
-                            <span class="rounded-circle bg-success" style="width: 8px; height: 8px;"></span>
-                            Resolved
-                        </span>
-                    </div>
-                    <p class="h4 fw-bold mb-0">@Model.ResolvedCount</p>
-                </div>
-            </div>
+            <partial name="_DashboardMetricCard" model="resolvedCard" />
         </div>
     </div>
 
-    <div class="d-flex align-items-center justify-content-between mb-3">
-        <h2 class="h5 fw-bold mb-0">Recent tickets</h2>
-        <a asp-controller="Tickets" asp-action="Index" class="btn btn-outline-secondary btn-sm rounded-2">View all</a>
+    <div class="row g-3 align-items-stretch">
+        <div class="col-12 col-lg-6">
+            <partial name="_DashboardPriorityChart" model="Model.PriorityBreakdown" />
+        </div>
+         <div class="col-12 col-lg-6">
+            <partial name="_DashboardRecentActivity" model="Model.RecentTickets" />
+        </div>
     </div>
-
-    @if (Model.RecentTickets.Count == 0)
-    {
-        <div class="card border-0 shadow-sm rounded-3">
-            <div class="card-body p-4 text-center text-body-secondary">
-                No tickets created yet.
-            </div>
-        </div>
-    }
-    else
-    {
-        <div class="row g-3">
-            @foreach (var ticket in Model.RecentTickets)
-            {
-                <div class="col-12 col-xl-6">
-                    <partial name="_TicketCard" model="ticket"/>
-                </div>
-            }
-        </div>
-    }
 </div>

--- a/DeskNin/Views/Settings/ChangePassword.cshtml
+++ b/DeskNin/Views/Settings/ChangePassword.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Change Password";
 }
 
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb small mb-0">
+        <li class="breadcrumb-item"><a asp-action="Index" class="text-decoration-none">Settings</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Change password</li>
+    </ol>
+</nav>
+
 <header class="mb-4">
     <h1 class="h3 fw-bold mb-1">Change Password</h1>
     <p class="text-body-secondary small mb-0">Update your account password</p>

--- a/DeskNin/Views/Settings/Index.cshtml
+++ b/DeskNin/Views/Settings/Index.cshtml
@@ -1,0 +1,90 @@
+@model SettingsIndexViewModel
+@{
+    ViewData["Title"] = "Settings";
+}
+
+<header class="mb-4">
+    <h1 class="h3 fw-bold mb-1">Settings</h1>
+    <p class="text-body-secondary small mb-0">Manage your account and preferences</p>
+</header>
+
+@if (TempData["SettingsSaved"] as bool? == true)
+{
+    <div class="alert alert-success alert-dismissible fade show rounded-3" role="alert">
+        Preferences saved.
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
+
+<div class="row g-4">
+    <div class="col-md-6 col-xl-4">
+        <div class="card h-100 border-0 shadow-sm rounded-3 desknin-settings-card">
+            <div class="card-body p-4 d-flex flex-column">
+                <div class="d-flex align-items-start gap-3 mb-3">
+                    <div class="rounded-3 bg-primary bg-opacity-10 p-2 text-primary flex-shrink-0">
+                        <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                    </div>
+                    <div>
+                        <h2 class="h6 fw-bold mb-1">Account security</h2>
+                        <p class="text-body-secondary small mb-0">Update your sign-in password.</p>
+                    </div>
+                </div>
+                <a asp-action="ChangePassword" class="btn btn-outline-primary rounded-2 mt-auto align-self-start">Change password</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6 col-xl-4">
+        <div class="card h-100 border-0 shadow-sm rounded-3 desknin-settings-card">
+            <div class="card-body p-4 d-flex flex-column">
+                <div class="d-flex align-items-start gap-3 mb-3">
+                    <div class="rounded-3 bg-primary bg-opacity-10 p-2 text-primary flex-shrink-0">
+                        <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+                    </div>
+                    <div>
+                        <h2 class="h6 fw-bold mb-1">System email</h2>
+                        <p class="text-body-secondary small mb-0">Turn outbound email on or off for the whole application (ticket notifications, etc.). SMTP or other delivery must still be configured separately.</p>
+                    </div>
+                </div>
+                @if (Model.CanManageSystemEmail)
+                {
+                    <form asp-action="SaveEmailNotifications" method="post" class="mt-auto">
+                        @Html.AntiForgeryToken()
+                        <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
+                            <div class="form-check form-switch mb-0">
+                                <input class="form-check-input" type="checkbox" role="switch" id="emailNotifications"
+                                       name="emailNotificationsEnabled" value="true"
+                                       @(Model.EmailNotificationsEnabled ? "checked" : null)/>
+                                <label class="form-check-label" for="emailNotifications">Enable outbound email</label>
+                            </div>
+                            <button type="submit" class="btn btn-sm btn-primary rounded-2">Save</button>
+                        </div>
+                    </form>
+                }
+                else
+                {
+                    <p class="small text-body-secondary mb-0 mt-auto">
+                        Current status:
+                        <span class="fw-semibold">@(Model.EmailNotificationsEnabled ? "Enabled" : "Disabled")</span>.
+                        Only an administrator can change this setting.
+                    </p>
+                }
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6 col-xl-4">
+        <div class="card h-100 border-0 shadow-sm rounded-3 desknin-settings-card">
+            <div class="card-body p-4 d-flex flex-column">
+                <div class="d-flex align-items-start gap-3 mb-3">
+                    <div class="rounded-3 bg-primary bg-opacity-10 p-2 text-primary flex-shrink-0">
+                        <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+                    </div>
+                    <div>
+                        <h2 class="h6 fw-bold mb-1">Appearance</h2>
+                        <p class="text-body-secondary small mb-0">Choose light or dark theme using the control at the side of the screen.</p>
+                    </div>
+                </div>
+                <p class="small text-body-secondary mb-0 mt-auto">The theme preference is stored in your browser.</p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/DeskNin/Views/Shared/_DashboardLayout.cshtml
+++ b/DeskNin/Views/Shared/_DashboardLayout.cshtml
@@ -29,25 +29,37 @@
             </div>
             <nav class="flex-grow-1 p-2 overflow-auto">
                 <ul class="nav flex-column gap-1">
+                    @if (!User.IsInRole("User") || User.IsInRole("Admin") || User.IsInRole("Technical"))
+                    {
+                        <li class="nav-item">
+                            <a class="nav-link d-flex align-items-center gap-2 rounded py-2 px-3 @(ViewContext.RouteData.Values["controller"]?.ToString() == "Dashboard" ? "active bg-primary text-white" : "text-body-secondary")" asp-controller="Dashboard" asp-action="Index">
+                                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+                                <span>Dashboard</span>
+                            </a>
+                        </li>
+                    }
                     <li class="nav-item">
-                        <a class="nav-link d-flex align-items-center gap-2 rounded py-2 px-3 @(ViewContext.RouteData.Values["controller"]?.ToString() == "Dashboard" ? "active bg-primary text-white" : "text-body-secondary")" asp-controller="Dashboard" asp-action="Index">
-                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
-                            <span>Dashboard</span>
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link d-flex align-items-center gap-2 rounded py-2 px-3 @(ViewContext.RouteData.Values["controller"]?.ToString() == "Tickets" ? "active bg-primary text-white" : "text-body-secondary")" asp-controller="Tickets" asp-action="Index">
+                        @{
+                            var isBasicUser = User.IsInRole("User") && !User.IsInRole("Admin") && !User.IsInRole("Technical");
+                            var ticketsHref = isBasicUser ? Url.Action("MyTickets", "Tickets") : Url.Action("Index", "Tickets");
+                            var ticketsLabel = isBasicUser ? "My tickets" : "Tickets";
+                            var isTicketsActive = ViewContext.RouteData.Values["controller"]?.ToString() == "Tickets";
+                        }
+                        <a class="nav-link d-flex align-items-center gap-2 rounded py-2 px-3 @(isTicketsActive ? "active bg-primary text-white" : "text-body-secondary")" href="@ticketsHref">
                             <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
-                            <span>Tickets</span>
+                            <span>@ticketsLabel</span>
                         </a>
                     </li>
                     @await Component.InvokeAsync("AdminNav")
-                    <li class="nav-item">
-                        <a class="nav-link d-flex align-items-center gap-2 rounded py-2 px-3 text-body-secondary" href="#">
-                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
-                            <span>Notifications</span>
-                        </a>
-                    </li>
+                    @if (User.IsInRole("Admin"))
+                    {
+                        <li class="nav-item">
+                            <a class="nav-link d-flex align-items-center gap-2 rounded py-2 px-3 text-body-secondary" href="#">
+                                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+                                <span>Notifications</span>
+                            </a>
+                        </li>
+                    }
                     <li class="nav-item">
                         <a class="nav-link d-flex align-items-center gap-2 rounded py-2 px-3 @(ViewContext.RouteData.Values["controller"]?.ToString() == "Settings" ? "active bg-primary text-white" : "text-body-secondary")" asp-controller="Settings" asp-action="ChangePassword">
                             <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
@@ -63,10 +75,9 @@
                     </div>
                     <div class="min-w-0 flex-grow-1">
                         <p class="mb-0 fw-bold text-truncate small" title="@User.Identity?.Name">@User.Identity?.Name</p>
-                        <p class="mb-0 text-body-secondary small">Administrator</p>
                     </div>
                 </div>
-                <form asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Action("Index", "Home")" method="post">
+                <form asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Page("/Account/Login", new { area = "Identity" })" method="post">
                     <button type="submit" class="btn btn-outline-danger btn-sm w-100 d-flex align-items-center justify-content-center p-2" title="Logout" aria-label="Logout">
                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
                     </button>

--- a/DeskNin/Views/Shared/_DashboardLayout.cshtml
+++ b/DeskNin/Views/Shared/_DashboardLayout.cshtml
@@ -23,7 +23,7 @@
     <div class="d-flex min-vh-100">
         <aside id="desknin-sidebar" class="desknin-sidebar d-flex flex-column bg-secondary border-end flex-shrink-0">
             <div class="p-3 border-bottom">
-                <a asp-controller="Dashboard" asp-action="Index" class="d-flex align-items-center gap-2 text-decoration-none text-body">
+                <a asp-controller="Home" asp-action="Index" class="d-flex align-items-center gap-2 text-decoration-none text-body">
                     <partial name="_Logo"/>
                 </a>
             </div>
@@ -61,7 +61,7 @@
                         </li>
                     }
                     <li class="nav-item">
-                        <a class="nav-link d-flex align-items-center gap-2 rounded py-2 px-3 @(ViewContext.RouteData.Values["controller"]?.ToString() == "Settings" ? "active bg-primary text-white" : "text-body-secondary")" asp-controller="Settings" asp-action="ChangePassword">
+                        <a class="nav-link d-flex align-items-center gap-2 rounded py-2 px-3 @(ViewContext.RouteData.Values["controller"]?.ToString() == "Settings" ? "active bg-primary text-white" : "text-body-secondary")" asp-controller="Settings" asp-action="Index">
                             <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
                             <span>Settings</span>
                         </a>

--- a/DeskNin/Views/Shared/_DashboardLayout.cshtml
+++ b/DeskNin/Views/Shared/_DashboardLayout.cshtml
@@ -51,15 +51,6 @@
                         </a>
                     </li>
                     @await Component.InvokeAsync("AdminNav")
-                    @if (User.IsInRole("Admin"))
-                    {
-                        <li class="nav-item">
-                            <a class="nav-link d-flex align-items-center gap-2 rounded py-2 px-3 text-body-secondary" href="#">
-                                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
-                                <span>Notifications</span>
-                            </a>
-                        </li>
-                    }
                     <li class="nav-item">
                         <a class="nav-link d-flex align-items-center gap-2 rounded py-2 px-3 @(ViewContext.RouteData.Values["controller"]?.ToString() == "Settings" ? "active bg-primary text-white" : "text-body-secondary")" asp-controller="Settings" asp-action="Index">
                             <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>

--- a/DeskNin/Views/Shared/_DashboardMetricCard.cshtml
+++ b/DeskNin/Views/Shared/_DashboardMetricCard.cshtml
@@ -1,0 +1,39 @@
+@model DeskNin.ViewModels.DashboardMetricCardViewModel
+
+<div class="card h-100 border-0 shadow-sm rounded-4 desknin-dashboard-metric-card">
+    <div class="card-body p-4">
+        <div class="d-flex align-items-start justify-content-between gap-3 mb-3">
+            <div class="d-flex flex-column">
+                <span class="d-flex align-items-center gap-2 small fw-medium text-body-secondary">
+                    <span class="rounded-circle @Model.AccentCssClass desknin-dashboard-metric-dot" aria-hidden="true"></span>
+                    @Model.Label
+                </span>
+            </div>
+
+            @{
+                var iconColorClass = Model.IconKind switch
+                {
+                    "open" => "text-primary",
+                    "in_progress" => "text-warning",
+                    "resolved" => "text-success",
+                    _ => "text-body-secondary"
+                };
+            }
+            <div class="desknin-dashboard-metric-icon @iconColorClass" aria-hidden="true">
+                @{
+                    var iconSvg = Model.IconKind switch
+                    {
+                        "open" => "<svg width=\"22\" height=\"22\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\"><rect x=\"3\" y=\"3\" width=\"7\" height=\"7\" rx=\"1\"/><rect x=\"14\" y=\"3\" width=\"7\" height=\"7\" rx=\"1\"/><rect x=\"3\" y=\"14\" width=\"7\" height=\"7\" rx=\"1\"/><path d=\"M14 14h7v7h-7z\"/></svg>",
+                        "in_progress" => "<svg width=\"22\" height=\"22\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\"><circle cx=\"12\" cy=\"12\" r=\"9\"/><path d=\"M12 7v5l3 2\"/><path d=\"M4 20c3-2 13-2 16 0\"/></svg>",
+                        "resolved" => "<svg width=\"22\" height=\"22\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\"><circle cx=\"12\" cy=\"12\" r=\"9\"/><path d=\"M9 12l2 2 4-5\"/></svg>",
+                        _ => ""
+                    };
+                }
+                @Html.Raw(iconSvg)
+            </div>
+        </div>
+
+        <p class="desknin-dashboard-metric-count mb-0 fw-bold">@Model.Count</p>
+    </div>
+</div>
+

--- a/DeskNin/Views/Shared/_DashboardPriorityChart.cshtml
+++ b/DeskNin/Views/Shared/_DashboardPriorityChart.cshtml
@@ -1,0 +1,42 @@
+@model IReadOnlyList<DeskNin.ViewModels.DashboardPriorityBucketViewModel>
+
+@{
+    var maxCount = Model.Count == 0 ? 0 : Model.Max(b => b.Count);
+    if (maxCount <= 0) maxCount = 1;
+}
+
+<section class="card border-0 shadow-sm rounded-3 h-100 desknin-dashboard-card">
+    <div class="card-body p-4">
+        <div class="d-flex align-items-center justify-content-between mb-3">
+            <h2 class="h6 fw-bold mb-0">Tickets by Priority</h2>
+        </div>
+
+        <div class="desknin-dashboard-priority-stack">
+            @foreach (var bucket in Model)
+            {
+                var width = (int)Math.Round((bucket.Count / (double)maxCount) * 100);
+                if (width < 0) width = 0;
+                if (width > 100) width = 100;
+
+                var accent = bucket.Label switch
+                {
+                    "Low" => "bg-primary",
+                    "Medium" => "bg-warning",
+                    "High" => "bg-danger",
+                    _ => "bg-secondary"
+                };
+
+                <div class="mb-3">
+                    <div class="d-flex align-items-baseline justify-content-between mb-2">
+                        <span class="small text-body-secondary">@bucket.Label</span>
+                        <span class="fw-semibold">@bucket.Count</span>
+                    </div>
+                    <div class="desknin-dashboard-priority-track">
+                        <div class="desknin-dashboard-priority-fill @accent" style="width:@width%"></div>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+</section>
+

--- a/DeskNin/Views/Shared/_DashboardRecentActivity.cshtml
+++ b/DeskNin/Views/Shared/_DashboardRecentActivity.cshtml
@@ -1,0 +1,56 @@
+@model IReadOnlyList<DeskNin.ViewModels.TicketItemViewModel>
+
+@functions {
+    private static string FormatAgo(DateTime utcTime)
+    {
+        var diff = DateTime.UtcNow - utcTime;
+        if (diff.TotalSeconds < 60) return "just now";
+        if (diff.TotalMinutes < 60) return $"{(int)diff.TotalMinutes}m ago";
+        if (diff.TotalHours < 48) return $"{(int)diff.TotalHours}h ago";
+        return utcTime.ToLocalTime().ToString("dd MMM");
+    }
+}
+
+<section class="card border-0 shadow-sm rounded-4 h-100 desknin-dashboard-card">
+    <div class="card-body p-4">
+        <div class="d-flex align-items-center justify-content-between mb-3">
+            <h2 class="h5 fw-bold mb-0">Recent tickets</h2>
+        </div>
+
+        @if (Model.Count == 0)
+        {
+            <div class="text-center text-body-secondary p-4">No recent tickets.</div>
+        }
+        else
+        {
+            <div class="desknin-dashboard-recent-list">
+                @foreach (var item in Model)
+                {
+                    <div class="desknin-dashboard-recent-row">
+                        <div class="min-w-0">
+                            <div class="text-truncate">
+                                <span class="desknin-dashboard-recent-id">#@item.Id</span>
+                                <span class="ms-2 text-truncate">@item.Title</span>
+                            </div>
+
+                            <div class="small text-body-secondary text-truncate mt-1">
+                                <span class="fw-semibold text-body-secondary">@item.AuthorName</span>
+                                <span class="mx-1">•</span>
+                                @{
+                                    var updated = item.UpdatedAtUtc > item.CreatedAtUtc;
+                                    var label = updated ? "Updated" : "Created";
+                                    var ago = updated ? FormatAgo(item.UpdatedAtUtc) : FormatAgo(item.CreatedAtUtc);
+                                }
+                                <span>@label @ago</span>
+                            </div>
+                        </div>
+                        <div class="flex-shrink-0">
+                            <partial name="_TicketStatusBadge" model="item.Status" />
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+    </div>
+</section>
+

--- a/DeskNin/Views/Shared/_LoginPartial.cshtml
+++ b/DeskNin/Views/Shared/_LoginPartial.cshtml
@@ -9,7 +9,7 @@
             <a class="nav-link" asp-area="Identity" asp-page="/Account/Manage/Index" title="Manage">Hello @User.Identity?.Name!</a>
         </li>
         <li class="nav-item">
-            <form class="form-inline mb-0" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Action("Index", "Home", new { area = "" })">
+            <form class="form-inline mb-0" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Page("/Account/Login", new { area = "Identity" })">
                 <button type="submit" class="nav-link btn btn-link px-2">Logout</button>
             </form>
         </li>

--- a/DeskNin/Views/Team/Edit.cshtml
+++ b/DeskNin/Views/Team/Edit.cshtml
@@ -54,16 +54,17 @@
 @section Scripts {
     <partial name="_ValidationScriptsPartial"/>
     <script>
-        function generatePassword() {
-            const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@@#$%';
-            let pwd = '';
-            for (let i = 0; i < 12; i++) pwd += chars.charAt(Math.floor(Math.random() * chars.length));
-            return pwd;
-        }
         document.getElementById('edit-pwd-generate').addEventListener('click', function () {
-            const pwd = generatePassword();
-            document.getElementById('edit-Password-display').value = pwd;
-            document.getElementById('edit-Password').value = pwd;
+            const btn = this;
+            btn.disabled = true;
+            fetch('@Url.Action("GeneratePassword", "Team")', { method: 'GET', headers: { 'Accept': 'application/json' } })
+                .then(r => r.ok ? r.json() : Promise.reject())
+                .then(data => {
+                    const pwd = data.password || '';
+                    document.getElementById('edit-Password-display').value = pwd;
+                    document.getElementById('edit-Password').value = pwd;
+                })
+                .finally(() => { btn.disabled = false; });
         });
         document.getElementById('edit-pwd-copy').addEventListener('click', function () {
             const pwd = document.getElementById('edit-Password-display').value;

--- a/DeskNin/Views/Team/Index.cshtml
+++ b/DeskNin/Views/Team/Index.cshtml
@@ -115,16 +115,17 @@
             document.getElementById('add-Password-display').value = '';
             document.getElementById('add-Password').value = '';
         });
-        function generatePassword() {
-            const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@@#$%';
-            let pwd = '';
-            for (let i = 0; i < 12; i++) pwd += chars.charAt(Math.floor(Math.random() * chars.length));
-            return pwd;
-        }
         document.getElementById('add-pwd-generate').addEventListener('click', function () {
-            const pwd = generatePassword();
-            document.getElementById('add-Password-display').value = pwd;
-            document.getElementById('add-Password').value = pwd;
+            const btn = this;
+            btn.disabled = true;
+            fetch('@Url.Action("GeneratePassword", "Team")', { method: 'GET', headers: { 'Accept': 'application/json' } })
+                .then(r => r.ok ? r.json() : Promise.reject())
+                .then(data => {
+                    const pwd = data.password || '';
+                    document.getElementById('add-Password-display').value = pwd;
+                    document.getElementById('add-Password').value = pwd;
+                })
+                .finally(() => { btn.disabled = false; });
         });
         document.getElementById('add-pwd-copy').addEventListener('click', function () {
             const pwd = document.getElementById('add-Password-display').value;

--- a/DeskNin/Views/Tickets/Create.cshtml
+++ b/DeskNin/Views/Tickets/Create.cshtml
@@ -6,6 +6,10 @@
 }
 
 <div class="mx-auto" style="max-width: 900px;">
+    @{
+        var isBasicUser = User.IsInRole("User") && !User.IsInRole("Admin") && !User.IsInRole("Technical");
+        var cancelAction = isBasicUser ? "MyTickets" : "Index";
+    }
     <header class="mb-4">
         <h1 class="h3 fw-bold mb-1">Create ticket</h1>
         <p class="text-body-secondary small mb-0">Submit a new support request.</p>
@@ -36,7 +40,7 @@
 
                 <div class="d-flex flex-wrap gap-2">
                     <button type="submit" class="btn btn-primary rounded-2">Create</button>
-                    <a asp-action="Index" class="btn btn-outline-secondary rounded-2">Cancel</a>
+                    <a asp-action="@cancelAction" class="btn btn-outline-secondary rounded-2">Cancel</a>
                 </div>
             </form>
         </div>

--- a/DeskNin/Views/Tickets/Details.cshtml
+++ b/DeskNin/Views/Tickets/Details.cshtml
@@ -7,6 +7,10 @@
 
 <div class="d-flex flex-column gap-4">
     <header class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+        @{
+            var isBasicUser = User.IsInRole("User") && !User.IsInRole("Admin") && !User.IsInRole("Technical");
+            var backAction = isBasicUser ? "MyTickets" : "Index";
+        }
         <div>
             <h1 class="h3 fw-bold mb-1">@Model.Ticket.Title</h1>
             <p class="text-body-secondary small mb-0">Ticket #@Model.Ticket.Id</p>
@@ -16,7 +20,7 @@
             {
                 <a asp-action="Edit" asp-route-id="@Model.Ticket.Id" class="btn btn-outline-secondary rounded-2">Edit</a>
             }
-            <a asp-action="Index" class="btn btn-outline-secondary rounded-2">Back to list</a>
+            <a asp-action="@backAction" class="btn btn-outline-secondary rounded-2">Back to list</a>
         </div>
     </header>
 

--- a/DeskNin/Views/Tickets/Details.cshtml
+++ b/DeskNin/Views/Tickets/Details.cshtml
@@ -104,28 +104,63 @@
                         </h2>
                     </div>
                     <div class="card-body p-4 d-flex flex-column gap-3">
-                        <form asp-action="Assign" method="post" class="desknin-workflow-block d-flex flex-column gap-2">
-                            <input type="hidden" name="id" value="@Model.Ticket.Id"/>
-                            <label class="form-label small mb-0 d-flex align-items-center gap-2">
-                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
-                                Assign technician
-                            </label>
-                            <select name="assignedTechnicianId" class="form-select rounded-2">
-                                <option value="">Unassigned</option>
-                                @foreach (var technician in Model.Technicians)
-                                {
-                                    if (technician.UserId == Model.Ticket.AssignedTechnicianId)
-                                    {
-                                        <option value="@technician.UserId" selected>@technician.Name</option>
-                                    }
-                                    else
-                                    {
-                                        <option value="@technician.UserId">@technician.Name</option>
-                                    }
+                        @{
+                            var isAdmin = User.IsInRole("Admin");
+                            var isTechnical = User.IsInRole("Technical");
+                            var currentUserId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+                            var isAssignedToMe = !string.IsNullOrEmpty(currentUserId) && Model.Ticket.AssignedTechnicianId == currentUserId;
+                        }
+
+                        @if (isTechnical && !isAdmin)
+                        {
+                            <form asp-action="Assign" method="post" class="desknin-workflow-block d-flex flex-column gap-2">
+                                <input type="hidden" name="id" value="@Model.Ticket.Id"/>
+                                @{
+                                    var canToggleAssignment = Model.Ticket.Status != TicketStatus.Closed;
+                                    var targetAssignedTechnicianId = isAssignedToMe ? "" : currentUserId;
+                                    var buttonText = isAssignedToMe ? "Unassign me" : "Assign me";
                                 }
-                            </select>
-                            <button type="submit" class="btn btn-primary btn-sm rounded-2">Save assignment</button>
-                        </form>
+                                <input type="hidden" name="assignedTechnicianId" value="@targetAssignedTechnicianId"/>
+                                <div class="d-flex align-items-center justify-content-between gap-2">
+                                    <label class="form-label small mb-0 d-flex align-items-center gap-2">
+                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                                        Assignment
+                                    </label>
+                                    @if (isAssignedToMe)
+                                    {
+                                        <span class="small text-body-secondary">Assigned to you</span>
+                                    }
+                                </div>
+                                <button type="submit" class="btn btn-primary btn-sm rounded-2" @(!canToggleAssignment ? "disabled" : "")>
+                                    @buttonText
+                                </button>
+                            </form>
+                        }
+                        else
+                        {
+                            <form asp-action="Assign" method="post" class="desknin-workflow-block d-flex flex-column gap-2">
+                                <input type="hidden" name="id" value="@Model.Ticket.Id"/>
+                                <label class="form-label small mb-0 d-flex align-items-center gap-2">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                                    Assign technician
+                                </label>
+                                <select name="assignedTechnicianId" class="form-select rounded-2">
+                                    <option value="">Unassigned</option>
+                                    @foreach (var technician in Model.Technicians)
+                                    {
+                                        if (technician.UserId == Model.Ticket.AssignedTechnicianId)
+                                        {
+                                            <option value="@technician.UserId" selected>@technician.Name</option>
+                                        }
+                                        else
+                                        {
+                                            <option value="@technician.UserId">@technician.Name</option>
+                                        }
+                                    }
+                                </select>
+                                <button type="submit" class="btn btn-primary btn-sm rounded-2">Save assignment</button>
+                            </form>
+                        }
 
                         <form asp-action="UpdateStatus" method="post" class="desknin-workflow-block d-flex flex-column gap-2">
                             <input type="hidden" name="id" value="@Model.Ticket.Id"/>

--- a/DeskNin/Views/Tickets/MyTickets.cshtml
+++ b/DeskNin/Views/Tickets/MyTickets.cshtml
@@ -11,6 +11,7 @@
             <h1 class="h3 fw-bold mb-1">My tickets</h1>
             <p class="text-body-secondary small mb-0">Track the tickets you created.</p>
         </div>
+        <a asp-action="Create" class="btn btn-primary rounded-2">Create ticket</a>
     </header>
 
     @{

--- a/DeskNin/Views/Tickets/MyTickets.cshtml
+++ b/DeskNin/Views/Tickets/MyTickets.cshtml
@@ -2,20 +2,19 @@
 @using DeskNin.Models
 
 @{
-    ViewData["Title"] = "Tickets";
+    ViewData["Title"] = "My tickets";
 }
 
 <div>
     <header class="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-4">
         <div>
-            <h1 class="h3 fw-bold mb-1">Tickets</h1>
-            <p class="text-body-secondary small mb-0">Track and manage support requests.</p>
+            <h1 class="h3 fw-bold mb-1">My tickets</h1>
+            <p class="text-body-secondary small mb-0">Track the tickets you created.</p>
         </div>
-        <a asp-action="Create" class="btn btn-primary rounded-2">Create ticket</a>
     </header>
 
     @{
-        var hasFilter = Model.SelectedStatus.HasValue || Model.AssignedToMe;
+        var hasFilter = Model.SelectedStatus.HasValue;
         var resetDisabledClass = hasFilter ? "" : " disabled";
     }
 
@@ -35,7 +34,7 @@
                     </div>
                 </div>
 
-                <div class="col-12 col-md-4">
+                <div class="col-12 col-md-5">
                     <div class="form-floating">
                         <select id="status" name="status" class="form-select rounded-2 desknin-filter-select">
                             <option value="">All</option>
@@ -55,21 +54,8 @@
                     </div>
                 </div>
 
-                <div class="col-12 col-md-3">
-                    <div class="d-flex justify-content-between align-items-center border rounded-2 px-3 py-2">
-                        <div class="min-w-0">
-                            <div class="fw-semibold small">Assignment</div>
-                            <div class="small text-body-secondary">Only tickets assigned to you</div>
-                        </div>
-                        <div class="form-check form-switch m-0 flex-shrink-0">
-                            <input class="form-check-input" type="checkbox" role="switch" value="true" id="assignedToMe" name="assignedToMe" @(Model.AssignedToMe ? "checked" : "")>
-                            <label class="form-check-label visually-hidden" for="assignedToMe">Assigned to me</label>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col-12 col-md-2 d-flex justify-content-md-end gap-2">
-                    <a asp-action="Index" class="btn btn-outline-secondary btn-sm rounded-2@resetDisabledClass">Reset</a>
+                <div class="col-12 col-md-4 d-flex justify-content-md-end gap-2">
+                    <a asp-action="MyTickets" asp-controller="Tickets" class="btn btn-outline-secondary btn-sm rounded-2@resetDisabledClass">Reset</a>
                     <button type="submit" class="btn btn-primary btn-sm rounded-2">Apply</button>
                 </div>
             </div>
@@ -96,3 +82,4 @@
         </div>
     }
 </div>
+

--- a/DeskNin/appsettings.Development.json
+++ b/DeskNin/appsettings.Development.json
@@ -9,6 +9,11 @@
     "DefaultAdminEmail": "admin@desknin.local",
     "DefaultAdminPassword": "Admin@123"
   },
+  "Resend": {
+    "ApiKey": "<RESEND_API_KEY>",
+    "FromEmail": "<RESEND_FROM_EMAIL>",
+    "LogoUrl": "<RESEND_LOGO_URL>"
+  },
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=desknin;Username=desknin-app;Password=desknin"
   }

--- a/DeskNin/wwwroot/css/dashboard.css
+++ b/DeskNin/wwwroot/css/dashboard.css
@@ -358,3 +358,16 @@
 .desknin-dashboard-recent-id {
   font-weight: 600;
 }
+
+/* Settings: card grid */
+.desknin-settings-card {
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.desknin-settings-card:hover {
+  box-shadow: 0 0.5rem 1rem rgba(15, 23, 42, 0.08) !important;
+}
+
+[data-bs-theme="dark"] .desknin-settings-card:hover {
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.35) !important;
+}

--- a/DeskNin/wwwroot/css/dashboard.css
+++ b/DeskNin/wwwroot/css/dashboard.css
@@ -106,6 +106,33 @@
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
+.desknin-ticket-card .text-body-secondary {
+  /* Keep consistency with our ticket typography colors */
+  color: #4b5563 !important;
+}
+
+[data-bs-theme="dark"] .desknin-ticket-card {
+  border-color: #334155;
+  background-color: #0f172a;
+}
+
+[data-bs-theme="dark"] .desknin-ticket-card:hover {
+  box-shadow: 0 10px 24px rgba(2, 6, 23, 0.45) !important;
+}
+
+[data-bs-theme="dark"] .desknin-ticket-number,
+[data-bs-theme="dark"] .desknin-ticket-title,
+[data-bs-theme="dark"] .desknin-ticket-author,
+[data-bs-theme="dark"] .desknin-ticket-time {
+  color: #e2e8f0;
+}
+
+[data-bs-theme="dark"] .desknin-ticket-card .text-body-secondary,
+[data-bs-theme="dark"] .desknin-ticket-description,
+[data-bs-theme="dark"] .desknin-ticket-working {
+  color: #94a3b8 !important;
+}
+
 .desknin-ticket-card:hover {
   transform: translateY(-1px);
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08) !important;
@@ -152,23 +179,31 @@
 }
 
 .desknin-ticket-status-open {
-  background-color: rgba(var(--bs-primary-rgb), 0.14);
-  color: var(--bs-primary);
+  /* Figma: primary blue */
+  background-color: rgba(37, 99, 235, 0.14);
+  color: #2563EB;
 }
 
 .desknin-ticket-status-progress {
-  background-color: #fef3c7;
-  color: #b45309;
+  /* Figma: warning yellow */
+  background-color: rgba(245, 158, 11, 0.18);
+  color: #F59E0B;
 }
 
 .desknin-ticket-status-resolved {
-  background-color: #d1fae5;
-  color: #047857;
+  /* Figma: success green */
+  background-color: rgba(16, 185, 129, 0.18);
+  color: #10B981;
 }
 
 .desknin-ticket-status-closed {
   background-color: #e5e7eb;
   color: #475569;
+}
+
+[data-bs-theme="dark"] .desknin-ticket-status-closed {
+  background-color: rgba(226, 232, 240, 0.14);
+  color: #e2e8f0;
 }
 
 .desknin-ticket-priority {
@@ -239,4 +274,87 @@
 
 [data-bs-theme="dark"] .desknin-filter-select {
   background: rgba(17, 24, 39, 0.85);
+}
+
+/* Dashboard overview (metric cards + priority chart + recent activity) */
+.desknin-dashboard-card {
+  background: var(--bs-card-bg, #fff);
+}
+
+.desknin-dashboard-priority-track {
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.desknin-dashboard-priority-fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.2s ease;
+}
+
+.desknin-dashboard-activity-list .desknin-dashboard-activity-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  margin-top: 6px;
+  flex: 0 0 auto;
+}
+
+[data-bs-theme="dark"] .desknin-dashboard-priority-track {
+  background: rgba(226, 232, 240, 0.14);
+}
+
+.desknin-dashboard-metric-dot {
+  width: 10px;
+  height: 10px;
+  display: inline-block;
+}
+
+.desknin-dashboard-metric-count {
+  font-size: 2rem;
+  line-height: 1.1;
+}
+
+.desknin-dashboard-metric-icon svg {
+  display: block;
+}
+
+/* Dashboard: Recent tickets list (frame) */
+.desknin-dashboard-recent-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.desknin-dashboard-recent-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  background: rgba(var(--bs-primary-rgb), 0.06);
+  border-radius: 0.75rem;
+}
+
+/* Mobile responsiveness: allow row to wrap instead of squeezing badge/text */
+@media (max-width: 575.98px) {
+  .desknin-dashboard-metric-count {
+    font-size: 1.75rem;
+  }
+
+  .desknin-dashboard-recent-row {
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
+    padding: 0.75rem 0.85rem;
+  }
+}
+
+[data-bs-theme="dark"] .desknin-dashboard-recent-row {
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.desknin-dashboard-recent-id {
+  font-weight: 600;
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,20 +5,46 @@
     build:
       context: .
       dockerfile: DeskNin/Dockerfile
-  
+    depends_on:
+      database:
+        condition: service_healthy
+      migrator:
+        condition: service_completed_successfully
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+    env_file:
+      - .env
+    ports:
+      - '8080:8080'
+    working_dir: /app
+
+
+  migrator:
+    image: mcr.microsoft.com/dotnet/sdk:10.0
+    container_name: desknin-migrator
+    working_dir: /src
+    volumes:
+      - ./:/src
+    env_file:
+      - .env
+    depends_on:
+      database:
+        condition: service_healthy
+    command: sh -c "export PATH=$PATH:/root/.dotnet/tools && dotnet tool install --global dotnet-ef && dotnet restore DeskNin/DeskNin.csproj && dotnet ef database update --project DeskNin/DeskNin.csproj --startup-project DeskNin/DeskNin.csproj"
+
   database:
     container_name: desknin-database
     image: postgres:15
     environment:
-      POSTGRES_USER: desknin-app
-      POSTGRES_PASSWORD: desknin
-      POSTGRES_DB: desknin
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
     ports:
       - '5432:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U ${DB_USER}']
+      test: ['CMD-SHELL', 'pg_isready -U ${DB_USER} -d ${DB_NAME}']
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Issue

Closes #4 

---

## What was done

Implemented the dashboard-overview branch scope, including dashboard UX, user/ticket flow refinements, system settings refactor, and email integration.

- Added dashboard overview with key ticket metrics, priority visualization, and recent activity components.
- Introduced `Tickets/MyTickets` flow and role-aware navigation/redirect behavior for better separation between end-users and admin/technical workflows.
- Improved ticket management UX (filters/defaults, details/create navigation behavior, assignment/status/priority/comment update paths).
- Refactored settings to a database-backed key-value model (`Setting`) and added system-wide email notifications toggle.
- Added Resend-based email infrastructure (sender, templates, notification orchestration) for onboarding, forgot password/reset password, and ticket update notifications.
- Added/updated service abstractions and tests around dashboard, settings, team, tickets, and email services.
- Updated Docker compose flow to support environment-based configuration and migration execution in containerized runs.

---

## Why

This branch delivers the dashboard overview milestone and consolidates core V1 operational flows around tickets, user experience, and communication.

It solves:
- Lack of a central operational overview for ticket workload/priorities.
- Mixed ticket experience between end-users and staff roles.
- Missing/fragile email communication flows and centralized notification control.
- Inconsistent local/container execution behavior for migrations and runtime settings.

---

## How to test


### Unit / Integration Tests

Describe how the tests validate the change.

- [x] Unit tests added or updated
- [ ] Integration tests executed

### Database

If applicable, describe database changes.

- [ ] No database changes
- [x] Migration added
- [x] Schema updated


## Checklist

- [x] Code follows project conventions
- [x] Self-review completed
- [x] Documentation updated if needed
- [x] No breaking changes introduced